### PR TITLE
Add put endpoints to save disqualified officers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,7 +18,11 @@
 *.zip
 *.tar.gz
 *.rar
+*.iml
 
 # virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*
 /target/
+
+#Intellij
+.idea

--- a/README.md
+++ b/README.md
@@ -28,4 +28,8 @@ test-unit            Run unit tests
 ## Endpoints
 | URL | Description |
 | --- | ----------- |
-| /disqualified-officers-data-api/healthcheck | Health check URL returns 200 if service is running |
+| /disqualified-officers/healthcheck | Health check URL returns 200 if service is running |
+| --- | ----------- |
+| /disqualified-officers/natural/{officerId}/internal | Save or update a natural disqualified officer record |
+| --- | ----------- |
+| /disqualified-officers/corporate/{officerId}/internal | Save or update a corporate disqualified officer record |

--- a/pom.xml
+++ b/pom.xml
@@ -4,8 +4,8 @@
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
         <groupId>uk.gov.companieshouse</groupId>
-        <artifactId>companies-house-parent</artifactId>
-        <version>1.3.0</version>
+        <artifactId>companies-house-spring-boot-parent</artifactId>
+        <version>1.5.0-rc1</version>
         <relativePath />
     </parent>
 	<artifactId>disqualified-officers-data-api</artifactId>
@@ -23,6 +23,13 @@
         <maven.compiler.target>${java.version}</maven.compiler.target>
         <maven-surefire-plugin.version>3.0.0-M5</maven-surefire-plugin.version>
         <jib-maven-plugin.version>3.1.1</jib-maven-plugin.version>
+        <io-cucumber.version>7.2.3</io-cucumber.version>
+
+        <!-- Internal -->
+        <structured-logging.version>1.9.12</structured-logging.version>
+        <private-api-sdk-java.version>2.0.137</private-api-sdk-java.version>
+        <api-sdk-manager-java-library.version>1.0.4</api-sdk-manager-java-library.version>
+        <api-helper-java-library.version>1.4.5</api-helper-java-library.version>
         
         <!--sonar configuration-->
         <sonar.coverage.jacoco.xmlReportPaths>${project.basedir}/target/site/jacoco/jacoco.xml,
@@ -54,12 +61,57 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-web</artifactId>
         </dependency>
-        
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-test</artifactId>
-			<scope>test</scope>
-		</dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.junit.jupiter</groupId>
+                    <artifactId>junit-jupiter-engine</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-data-mongodb</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.logging.log4j</groupId>
+                    <artifactId>log4j-to-slf4j</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>uk.gov.companieshouse</groupId>
+            <artifactId>structured-logging</artifactId>
+            <version>${structured-logging.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>uk.gov.companieshouse</groupId>
+            <artifactId>private-api-sdk-java</artifactId>
+            <version>${private-api-sdk-java.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>uk.gov.companieshouse</groupId>
+            <artifactId>api-sdk-manager-java-library</artifactId>
+            <version>${api-sdk-manager-java-library.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>uk.gov.companieshouse</groupId>
+            <artifactId>api-helper-java</artifactId>
+            <version>${api-helper-java-library.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.cucumber</groupId>
+            <artifactId>cucumber-junit</artifactId>
+            <version>${io-cucumber.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+        </dependency>
 	</dependencies>
 
 	<build>

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
 
         <!-- Internal -->
         <structured-logging.version>1.9.12</structured-logging.version>
-        <private-api-sdk-java.version>2.0.137</private-api-sdk-java.version>
+        <private-api-sdk-java.version>2.0.141</private-api-sdk-java.version>
         <api-sdk-manager-java-library.version>1.0.4</api-sdk-manager-java-library.version>
         <api-helper-java-library.version>1.4.5</api-helper-java-library.version>
         

--- a/routes.yaml
+++ b/routes.yaml
@@ -3,3 +3,5 @@ group: api
 weight: 905
 routes:
   1: ^/disqualified-officers-data-api/healthcheck
+  2: ^/disqualified-officers-data-api/natural/(.*)/internal
+  3: ^/disqualified-officers-data-api/corporate/(.*)/internal

--- a/routes.yaml
+++ b/routes.yaml
@@ -2,6 +2,6 @@ app_name: disqualified-officers-data-api
 group: api
 weight: 905
 routes:
-  1: ^/disqualified-officers-data-api/healthcheck
-  2: ^/disqualified-officers-data-api/natural/(.*)/internal
-  3: ^/disqualified-officers-data-api/corporate/(.*)/internal
+  1: ^/disqualified-officers/healthcheck
+  2: ^/disqualified-officers/natural/(.*)/internal
+  3: ^/disqualified-officers/corporate/(.*)/internal

--- a/src/main/java/uk/gov/companieshouse/disqualifiedofficersdataapi/config/ApplicationConfig.java
+++ b/src/main/java/uk/gov/companieshouse/disqualifiedofficersdataapi/config/ApplicationConfig.java
@@ -12,14 +12,15 @@ import javax.annotation.PostConstruct;
 
 @Configuration
 public class ApplicationConfig {
+    
+    @Autowired
+    private MappingMongoConverter mappingMongoConverter;
 
     @Bean
     EnvironmentReader environmentReader() {
         return new EnvironmentReaderImpl();
     }
 
-    @Autowired
-    private MappingMongoConverter mappingMongoConverter;
 
     /**
      * Converter to remove _class from the mongo record during saving

--- a/src/main/java/uk/gov/companieshouse/disqualifiedofficersdataapi/config/ApplicationConfig.java
+++ b/src/main/java/uk/gov/companieshouse/disqualifiedofficersdataapi/config/ApplicationConfig.java
@@ -1,0 +1,31 @@
+package uk.gov.companieshouse.disqualifiedofficersdataapi.config;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.mongodb.core.convert.DefaultMongoTypeMapper;
+import org.springframework.data.mongodb.core.convert.MappingMongoConverter;
+import uk.gov.companieshouse.environment.EnvironmentReader;
+import uk.gov.companieshouse.environment.impl.EnvironmentReaderImpl;
+
+import javax.annotation.PostConstruct;
+
+@Configuration
+public class ApplicationConfig {
+
+    @Bean
+    EnvironmentReader environmentReader() {
+        return new EnvironmentReaderImpl();
+    }
+
+    @Autowired
+    private MappingMongoConverter mappingMongoConverter;
+
+    /**
+     * Converter to remove _class from the mongo record during saving
+     */
+    @PostConstruct
+    public void createConverterToRemoveClassName() {
+        mappingMongoConverter.setTypeMapper(new DefaultMongoTypeMapper(null));
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/disqualifiedofficersdataapi/config/LoggingConfig.java
+++ b/src/main/java/uk/gov/companieshouse/disqualifiedofficersdataapi/config/LoggingConfig.java
@@ -1,0 +1,27 @@
+package uk.gov.companieshouse.disqualifiedofficersdataapi.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import uk.gov.companieshouse.logging.Logger;
+import uk.gov.companieshouse.logging.LoggerFactory;
+
+/**
+ * Configuration class for logging.
+ */
+@Configuration
+public class LoggingConfig {
+
+    @Value("${logger.namespace}")
+    private String loggerNamespace;
+
+    /**
+     * Creates a logger with specified namespace.
+     *
+     * @return the {@link LoggerFactory} for the specified namespace
+     */
+    @Bean
+    public Logger logger() {
+        return LoggerFactory.getLogger(loggerNamespace);
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/disqualifiedofficersdataapi/config/MongoDisqualificationsConfig.java
+++ b/src/main/java/uk/gov/companieshouse/disqualifiedofficersdataapi/config/MongoDisqualificationsConfig.java
@@ -1,0 +1,50 @@
+package uk.gov.companieshouse.disqualifiedofficersdataapi.config;
+
+import com.mongodb.ConnectionString;
+import com.mongodb.MongoClientSettings;
+import com.mongodb.client.MongoClient;
+import com.mongodb.client.MongoClients;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.mongodb.MongoDatabaseFactory;
+import org.springframework.data.mongodb.MongoTransactionManager;
+import org.springframework.data.mongodb.config.AbstractMongoClientConfiguration;
+import org.springframework.transaction.annotation.EnableTransactionManagement;
+
+@ConditionalOnProperty(name = "mongodb.disqualifications.disqualifications", havingValue = "true")
+@Configuration
+@EnableTransactionManagement
+public class MongoDisqualificationsConfig extends AbstractMongoClientConfiguration {
+
+    @Value("${spring.data.mongodb.name}")
+    private String databaseName;
+
+    @Value("${spring.data.mongodb.uri}")
+    private String databaseUri;
+
+    @Bean
+    MongoTransactionManager transactionManager(MongoDatabaseFactory dbFactory) {
+        return new MongoTransactionManager(dbFactory);
+    }
+
+    @Override
+    protected String getDatabaseName() {
+        return this.databaseName;
+    }
+
+    protected String getDatabaseUri() {
+        return this.databaseUri;
+    }
+
+    @Override
+    public MongoClient mongoClient() {
+        final ConnectionString connectionString =
+                new ConnectionString(getDatabaseUri());
+        final MongoClientSettings mongoClientSettings = MongoClientSettings.builder()
+                .applyConnectionString(connectionString)
+                .build();
+        return MongoClients.create(mongoClientSettings);
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/disqualifiedofficersdataapi/controller/DisqualifiedOfficerController.java
+++ b/src/main/java/uk/gov/companieshouse/disqualifiedofficersdataapi/controller/DisqualifiedOfficerController.java
@@ -32,7 +32,7 @@ public class DisqualifiedOfficerController {
      * @param  requestBody  the request body containing disqualified officer data
      * @return  no response
      */
-    @PutMapping("/disqualified-officers-data-api/natural/{officer_id}/internal")
+    @PutMapping("/disqualified-officers/natural/{officer_id}/internal")
     public ResponseEntity<Void> naturalDisqualifiedOfficer(
             @RequestHeader("x-request-id") String contextId,
             @PathVariable("officer_id") String officerId,
@@ -56,7 +56,7 @@ public class DisqualifiedOfficerController {
      * @param  requestBody  the request body containing disqualified officer data
      * @return  no response
      */
-    @PutMapping("/disqualified-officers-data-api/corporate/{officer_id}/internal")
+    @PutMapping("/disqualified-officers/corporate/{officer_id}/internal")
     public ResponseEntity<Void> corporateDisqualifiedOfficer(
             @RequestHeader("x-request-id") String contextId,
             @PathVariable("officer_id") String officerId,

--- a/src/main/java/uk/gov/companieshouse/disqualifiedofficersdataapi/controller/DisqualifiedOfficerController.java
+++ b/src/main/java/uk/gov/companieshouse/disqualifiedofficersdataapi/controller/DisqualifiedOfficerController.java
@@ -1,0 +1,73 @@
+package uk.gov.companieshouse.disqualifiedofficersdataapi.controller;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RestController;
+
+import uk.gov.companieshouse.api.disqualification.InternalCorporateDisqualificationApi;
+import uk.gov.companieshouse.api.disqualification.InternalNaturalDisqualificationApi;
+import uk.gov.companieshouse.disqualifiedofficersdataapi.service.DisqualifiedOfficerService;
+
+import uk.gov.companieshouse.logging.Logger;
+
+@RestController
+public class DisqualifiedOfficerController {
+
+    @Autowired
+    private Logger logger;
+    @Autowired
+    private DisqualifiedOfficerService service;
+
+
+    /**
+     * PUT request to save or update a Natural Disqualified Officer.
+     *
+     * @param  officerId  the id for the disqualified officer
+     * @param  requestBody  the request body containing disqualified officer data
+     * @return  no response
+     */
+    @PutMapping("/disqualified-officers-data-api/natural/{officer_id}/internal")
+    public ResponseEntity<Void> naturalDisqualifiedOfficer(
+            @RequestHeader("x-request-id") String contextId,
+            @PathVariable("officer_id") String officerId,
+            @RequestBody InternalNaturalDisqualificationApi requestBody
+    ) throws JsonProcessingException {
+        logger.info(String.format(
+                "Processing disqualified officer information for officer id %s",
+                officerId));
+
+        service.processNaturalDisqualification(contextId, officerId, requestBody);
+
+        return ResponseEntity.status(HttpStatus.OK).build();
+    }
+
+
+
+    /**
+     * PUT request to save or update a Corporate Disqualified Officers.
+     *
+     * @param  officerId  the id for the disqualified officer
+     * @param  requestBody  the request body containing disqualified officer data
+     * @return  no response
+     */
+    @PutMapping("/disqualified-officers-data-api/corporate/{officer_id}/internal")
+    public ResponseEntity<Void> corporateDisqualifiedOfficer(
+            @RequestHeader("x-request-id") String contextId,
+            @PathVariable("officer_id") String officerId,
+            @RequestBody InternalCorporateDisqualificationApi requestBody
+    ) throws JsonProcessingException {
+        logger.info(String.format(
+                "Processing disqualified officer information for officer id %s",
+                officerId));
+
+        service.processCorporateDisqualification(contextId, officerId, requestBody);
+
+        return ResponseEntity.status(HttpStatus.OK).build();
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/disqualifiedofficersdataapi/controller/HealthCheckController.java
+++ b/src/main/java/uk/gov/companieshouse/disqualifiedofficersdataapi/controller/HealthCheckController.java
@@ -1,0 +1,15 @@
+package uk.gov.companieshouse.disqualifiedofficersdataapi.controller;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class HealthCheckController {
+
+    @GetMapping("/healthcheck")
+    public ResponseEntity<Void> healthcheck() {
+        return ResponseEntity.status(HttpStatus.OK).build();
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/disqualifiedofficersdataapi/model/CorporateDisqualificationDocument.java
+++ b/src/main/java/uk/gov/companieshouse/disqualifiedofficersdataapi/model/CorporateDisqualificationDocument.java
@@ -1,0 +1,17 @@
+package uk.gov.companieshouse.disqualifiedofficersdataapi.model;
+
+import uk.gov.companieshouse.api.disqualification.CorporateDisqualificationApi;
+
+public class CorporateDisqualificationDocument extends DisqualificationDocument {
+
+    private CorporateDisqualificationApi data;
+
+    public CorporateDisqualificationApi getData() {
+        return data;
+    }
+
+    public CorporateDisqualificationDocument setData(CorporateDisqualificationApi data) {
+        this.data = data;
+        return this;
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/disqualifiedofficersdataapi/model/Created.java
+++ b/src/main/java/uk/gov/companieshouse/disqualifiedofficersdataapi/model/Created.java
@@ -1,0 +1,18 @@
+package uk.gov.companieshouse.disqualifiedofficersdataapi.model;
+
+import java.time.LocalDateTime;
+
+public class Created {
+
+    private LocalDateTime at;
+
+    public LocalDateTime getAt() {
+        return at;
+    }
+
+    public Created setAt(LocalDateTime at) {
+        this.at = at;
+        return this;
+    }
+}
+

--- a/src/main/java/uk/gov/companieshouse/disqualifiedofficersdataapi/model/DisqualificationDocument.java
+++ b/src/main/java/uk/gov/companieshouse/disqualifiedofficersdataapi/model/DisqualificationDocument.java
@@ -1,0 +1,98 @@
+package uk.gov.companieshouse.disqualifiedofficersdataapi.model;
+
+import org.springframework.data.mongodb.core.mapping.Document;
+
+import javax.persistence.Id;
+
+@Document(collection = "#{@environment.getProperty('mongodb.disqualifications.collection.name')}")
+public class DisqualificationDocument {
+
+    @Id
+    private String id;
+
+    private String officerDisqId;
+
+    private String officerDetailId;
+
+    private String officerIdRaw;
+
+    private Created created;
+
+    private String deltaAt;
+
+    private boolean isCorporateOfficer;
+
+    private Updated updated;
+
+    public String getId() {
+        return id;
+    }
+
+    public DisqualificationDocument setId(String id) {
+        this.id = id;
+        return this;
+    }
+
+    public String getOfficerDisqId() {
+        return officerDisqId;
+    }
+
+    public DisqualificationDocument setOfficerDisqId(String officerDisqId) {
+        this.officerDisqId = officerDisqId;
+        return this;
+    }
+
+    public String getOfficerDetailId() {
+        return officerDetailId;
+    }
+
+    public DisqualificationDocument setOfficerDetailId(String officerDetailId) {
+        this.officerDetailId = officerDetailId;
+        return this;
+    }
+
+    public String getOfficerIdRaw() {
+        return officerIdRaw;
+    }
+
+    public DisqualificationDocument setOfficerIdRaw(String officerIdRaw) {
+        this.officerIdRaw = officerIdRaw;
+        return this;
+    }
+
+    public Created getCreated() {
+        return created;
+    }
+
+    public DisqualificationDocument setCreated(Created created) {
+        this.created = created;
+        return this;
+    }
+
+    public String getDeltaAt() {
+        return deltaAt;
+    }
+
+    public DisqualificationDocument setDeltaAt(String deltaAt) {
+        this.deltaAt = deltaAt;
+        return this;
+    }
+
+    public boolean isCorporateOfficer() {
+        return isCorporateOfficer;
+    }
+
+    public DisqualificationDocument setCorporateOfficer(boolean corporateOfficer) {
+        isCorporateOfficer = corporateOfficer;
+        return this;
+    }
+
+    public Updated getUpdated() {
+        return updated;
+    }
+
+    public DisqualificationDocument setUpdated(Updated updated) {
+        this.updated = updated;
+        return this;
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/disqualifiedofficersdataapi/model/NaturalDisqualificationDocument.java
+++ b/src/main/java/uk/gov/companieshouse/disqualifiedofficersdataapi/model/NaturalDisqualificationDocument.java
@@ -1,0 +1,17 @@
+package uk.gov.companieshouse.disqualifiedofficersdataapi.model;
+
+import uk.gov.companieshouse.api.disqualification.NaturalDisqualificationApi;
+
+public class NaturalDisqualificationDocument extends DisqualificationDocument {
+
+    private NaturalDisqualificationApi data;
+
+    public NaturalDisqualificationApi getData() {
+        return data;
+    }
+
+    public NaturalDisqualificationDocument setData(NaturalDisqualificationApi data) {
+        this.data = data;
+        return this;
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/disqualifiedofficersdataapi/model/Updated.java
+++ b/src/main/java/uk/gov/companieshouse/disqualifiedofficersdataapi/model/Updated.java
@@ -1,0 +1,17 @@
+package uk.gov.companieshouse.disqualifiedofficersdataapi.model;
+
+import java.time.LocalDateTime;
+
+public class Updated {
+
+    private LocalDateTime at;
+
+    public LocalDateTime getAt() {
+        return at;
+    }
+
+    public Updated setAt(LocalDateTime at) {
+        this.at = at;
+        return this;
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/disqualifiedofficersdataapi/repository/DisqualifiedOfficerRepository.java
+++ b/src/main/java/uk/gov/companieshouse/disqualifiedofficersdataapi/repository/DisqualifiedOfficerRepository.java
@@ -1,0 +1,15 @@
+package uk.gov.companieshouse.disqualifiedofficersdataapi.repository;
+
+import org.springframework.data.mongodb.repository.MongoRepository;
+import org.springframework.data.mongodb.repository.Query;
+import org.springframework.stereotype.Repository;
+import uk.gov.companieshouse.disqualifiedofficersdataapi.model.DisqualificationDocument;
+
+import java.util.List;
+
+@Repository
+public interface DisqualifiedOfficerRepository extends MongoRepository<DisqualificationDocument, String> {
+
+    @Query("{'_id': ?0, 'updated.at':{$gte : { \"$date\" : \"?1\" } }}")
+    List findUpdatedDisqualification(String officerId, String at);
+}

--- a/src/main/java/uk/gov/companieshouse/disqualifiedofficersdataapi/service/DisqualifiedOfficerService.java
+++ b/src/main/java/uk/gov/companieshouse/disqualifiedofficersdataapi/service/DisqualifiedOfficerService.java
@@ -1,0 +1,108 @@
+package uk.gov.companieshouse.disqualifiedofficersdataapi.service;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import uk.gov.companieshouse.api.disqualification.InternalCorporateDisqualificationApi;
+import uk.gov.companieshouse.api.disqualification.InternalNaturalDisqualificationApi;
+import uk.gov.companieshouse.disqualifiedofficersdataapi.model.Created;
+import uk.gov.companieshouse.disqualifiedofficersdataapi.model.DisqualificationDocument;
+import uk.gov.companieshouse.disqualifiedofficersdataapi.repository.DisqualifiedOfficerRepository;
+import uk.gov.companieshouse.disqualifiedofficersdataapi.transform.DisqualificationTransformer;
+
+import java.time.OffsetDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+import java.util.Optional;
+
+@Service
+public class DisqualifiedOfficerService {
+
+    @Autowired
+    private DisqualifiedOfficerRepository repository;
+    @Autowired
+    private DisqualificationTransformer transformer;
+
+    private final DateTimeFormatter dateTimeFormatter =
+            DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss'Z'");
+
+    /**
+     * Save or update a natural disqualification
+     * @param contextId     Id used for chsKafkaCall
+     * @param officerId     Id used for mongo record
+     * @param requestBody   Data to be saved
+     */
+    public void processNaturalDisqualification(String contextId, String officerId,
+                                               InternalNaturalDisqualificationApi requestBody) {
+
+        boolean isLatestRecord = isLatestRecord(officerId, requestBody.getInternalData().getDeltaAt());
+
+        if (isLatestRecord) {
+
+            DisqualificationDocument document = transformer.transformNaturalDisqualifiedOfficer(officerId, requestBody);
+
+            saveAndCallChsKafka(contextId, officerId, document);
+        }
+    }
+
+    /**
+     * Save or update a corporate disqualification
+     * @param contextId     Id used for chsKafkaCall
+     * @param officerId     Id used for mongo record
+     * @param requestBody   Data to be saved
+     */
+    public void processCorporateDisqualification(String contextId, String officerId,
+                                                 InternalCorporateDisqualificationApi requestBody) {
+
+        boolean isLatestRecord = isLatestRecord(officerId, requestBody.getInternalData().getDeltaAt());
+
+        if (isLatestRecord) {
+
+            DisqualificationDocument document = transformer.transformCorporateDisqualifiedOfficer(officerId, requestBody);
+
+            saveAndCallChsKafka(contextId, officerId, document);
+        }
+    }
+
+    /**
+     * Check the record hasn't been update more recently
+     * @param officerId Mongo Id
+     * @param deltaAt   Time of update
+     * @return isLatestRecord True if we are updating the latest record
+     */
+    private boolean isLatestRecord(String officerId, OffsetDateTime deltaAt) {
+        String formattedDate = deltaAt.format(dateTimeFormatter);
+        List disqualifications = repository.findUpdatedDisqualification(officerId, formattedDate);
+        return disqualifications.isEmpty();
+    }
+
+    /**
+     * Save or update the mongo record
+     * @param contextId Chs kafka id
+     * @param officerId Mongo id
+     * @param document  Transformed Data
+     */
+    private void saveAndCallChsKafka(String contextId, String officerId, DisqualificationDocument document) {
+        Created created = getCreatedFromCurrentRecord(officerId);
+        if(created == null) {
+            document.setCreated(new Created().setAt(document.getUpdated().getAt()));
+        } else {
+            document.setCreated(created);
+        }
+
+        repository.save(document);
+
+        //TODO - call the chs kafka api
+    }
+
+    /**
+     * Check whether we are updating a record and if so persist created time
+     * @param officerId Mongo Id
+     * @return created if this is an update save the previous created to the new document
+     */
+    private Created getCreatedFromCurrentRecord(String officerId) {
+        Optional<DisqualificationDocument> doc = repository.findById(officerId);
+
+        return doc.isPresent() ? doc.get().getCreated(): null;
+    }
+
+}

--- a/src/main/java/uk/gov/companieshouse/disqualifiedofficersdataapi/transform/DisqualificationTransformer.java
+++ b/src/main/java/uk/gov/companieshouse/disqualifiedofficersdataapi/transform/DisqualificationTransformer.java
@@ -1,0 +1,83 @@
+package uk.gov.companieshouse.disqualifiedofficersdataapi.transform;
+
+import org.springframework.stereotype.Component;
+import uk.gov.companieshouse.GenerateEtagUtil;
+import uk.gov.companieshouse.api.disqualification.CorporateDisqualificationApi;
+import uk.gov.companieshouse.api.disqualification.InternalCorporateDisqualificationApi;
+import uk.gov.companieshouse.api.disqualification.InternalDisqualificationApiInternalData;
+import uk.gov.companieshouse.api.disqualification.InternalNaturalDisqualificationApi;
+import uk.gov.companieshouse.disqualifiedofficersdataapi.model.CorporateDisqualificationDocument;
+import uk.gov.companieshouse.disqualifiedofficersdataapi.model.DisqualificationDocument;
+import uk.gov.companieshouse.disqualifiedofficersdataapi.model.NaturalDisqualificationDocument;
+import uk.gov.companieshouse.disqualifiedofficersdataapi.model.Updated;
+
+import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
+import java.time.format.DateTimeFormatter;
+
+@Component
+public class DisqualificationTransformer {
+
+    private final DateTimeFormatter dateTimeFormatter =
+        DateTimeFormatter.ofPattern("yyyyMMddHHmmssSSSSSS");
+
+    /**
+     * Transform the internal data class to a mongo ready document
+     * @param officerId     Mongo Id
+     * @param requestBody   Internal data class
+     * @return document     Mongo wrapper document
+     */
+    public DisqualificationDocument transformNaturalDisqualifiedOfficer(
+            String officerId, InternalNaturalDisqualificationApi requestBody) {
+
+        NaturalDisqualificationDocument document = new NaturalDisqualificationDocument();
+
+        requestBody.getExternalData().setEtag(GenerateEtagUtil.generateEtag());
+
+        document.setData(requestBody.getExternalData())
+                .setId(officerId)
+                .setCorporateOfficer(false);
+
+        return transformDisqualifiedOfficer(document, requestBody.getInternalData());
+    }
+
+    /**
+     * Transform the internal data class to a mongo ready document
+     * @param officerId     Mongo Id
+     * @param requestBody   Internal data class
+     * @return document     Mongo wrapper document
+     */
+    public DisqualificationDocument transformCorporateDisqualifiedOfficer(
+            String officerId, InternalCorporateDisqualificationApi requestBody) {
+
+        CorporateDisqualificationDocument document = new CorporateDisqualificationDocument();
+
+        requestBody.getExternalData().setEtag(GenerateEtagUtil.generateEtag());
+
+        document.setData(requestBody.getExternalData())
+                .setId(officerId)
+                .setCorporateOfficer(true);
+
+        return transformDisqualifiedOfficer(document, requestBody.getInternalData());
+    }
+
+    /**
+     * Complete officer type inspecific mappings
+     * @param document     Mongo wrapper document
+     * @param internalData Internal data class
+     * @return document
+     */
+    private DisqualificationDocument transformDisqualifiedOfficer(
+            DisqualificationDocument document,
+            InternalDisqualificationApiInternalData internalData) {
+
+        OffsetDateTime deltaAt = internalData.getDeltaAt();
+
+        document.setUpdated(new Updated().setAt(LocalDateTime.now()))
+                .setOfficerIdRaw(internalData.getOfficerIdRaw())
+                .setOfficerDetailId(internalData.getOfficerDetailId())
+                .setOfficerDisqId(internalData.getOfficerDisqId())
+                .setDeltaAt(dateTimeFormatter.format(deltaAt));
+        return document;
+    }
+}

--- a/src/main/resources/Disqualification.json
+++ b/src/main/resources/Disqualification.json
@@ -1,0 +1,69 @@
+{
+  "_id" : "string",
+  "officer_disq_id" : "string",
+  "officer_detail_id" : "string",
+  "data" : {
+    "person_number" : "string",
+    "date_of_birth" : "date",
+    "disqualifications" : [
+      {
+        "address" : {
+          "address_line_1" : "string",
+          "address_line_2" : "string",
+          "locality" : "string",
+          "postal_code" : "string",
+          "premises" : "string",
+          "region" : "string"
+        },
+        "case_identifier" : "string",
+        "company_names" : [
+          "string"
+        ],
+        "court_name" : "string",
+        "disqualification_type" : "string",
+        "disqualified_from" : "date",
+        "disqualified_until" : "date",
+        "heard_on" : "date",
+        "undertaken_on" : "date",
+        "reason" : {
+          "description_identifier" : "string",
+          "section" : "string",
+          "act" : "string",
+          "article" : "string"
+        },
+        "last_variation" : {
+          "court_name" : "string",
+          "case_identifier" : "string",
+          "varied_on" : "date"
+        }
+      }
+    ],
+    "etag" : "string",
+    "title" : "string",
+    "forename" : "string",
+    "other_forename" : "string",
+    "surname" : "string",
+    "honours" : "string",
+    "nationality" : "string",
+    "company_number" : "string",
+    "country_of_registration" : "string",
+    "permissions_to_act" : {
+      "court_name" : "string",
+      "granted_on" : "date",
+      "expired_on" : "date",
+      "purpose" : "string",
+      "company_names" : [
+        "string"
+      ]
+    },
+    "links" : {
+      "self" : "string"
+    }
+  },
+  "delta_at" : "string",
+  "is_corporate_officer" : "boolean",
+  "officer_id_raw" : "string",
+  "updated" : {
+    "at" : "string"
+  }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,2 +1,0 @@
-management.endpoints.web.base-path=/disqualified-officers-data-api
-management.endpoints.web.path-mapping.health=/healthcheck

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,0 +1,20 @@
+management:
+  endpoints:
+    web:
+      base-path: /disqualified-officers-data-api
+      path-mapping:
+        health: /healthcheck
+
+logger:
+  namespace: disqualified-officer-data-api
+
+spring:
+  data:
+    mongodb:
+      uri: ${MONGODB_URL:mongodb://mongo:27017/disqualifications?retryWrites=false}
+      name: disqualifications
+
+mongodb:
+  disqualifications:
+    collection:
+      name: disqualifications

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,7 +1,7 @@
 management:
   endpoints:
     web:
-      base-path: /disqualified-officers-data-api
+      base-path: /disqualified-officers
       path-mapping:
         health: /healthcheck
 

--- a/src/test/java/uk/gov/companieshouse/disqualifiedofficersdataapi/service/DisqualifiedOfficerServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/disqualifiedofficersdataapi/service/DisqualifiedOfficerServiceTest.java
@@ -1,0 +1,126 @@
+package uk.gov.companieshouse.disqualifiedofficersdataapi.service;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.companieshouse.api.disqualification.InternalCorporateDisqualificationApi;
+import uk.gov.companieshouse.api.disqualification.InternalDisqualificationApiInternalData;
+import uk.gov.companieshouse.api.disqualification.InternalNaturalDisqualificationApi;
+import uk.gov.companieshouse.disqualifiedofficersdataapi.model.Created;
+import uk.gov.companieshouse.disqualifiedofficersdataapi.model.DisqualificationDocument;
+import uk.gov.companieshouse.disqualifiedofficersdataapi.model.NaturalDisqualificationDocument;
+import uk.gov.companieshouse.disqualifiedofficersdataapi.model.Updated;
+import uk.gov.companieshouse.disqualifiedofficersdataapi.repository.DisqualifiedOfficerRepository;
+import uk.gov.companieshouse.disqualifiedofficersdataapi.transform.DisqualificationTransformer;
+
+import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import static com.mongodb.assertions.Assertions.assertNull;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+public class DisqualifiedOfficerServiceTest {
+
+    private static final String OFFICER_ID = "officerId";
+
+    @Mock
+    private DisqualifiedOfficerRepository repository;
+
+    @Mock
+    private DisqualificationTransformer transformer;
+
+    @Captor
+    private ArgumentCaptor<String> dateCaptor;
+
+    @InjectMocks
+    private DisqualifiedOfficerService service;
+
+    private InternalNaturalDisqualificationApi request;
+    private InternalCorporateDisqualificationApi corpRequest;
+    private DisqualificationDocument document;
+    private String dateString;
+
+    @BeforeEach
+    public void setUp() {
+        OffsetDateTime date = OffsetDateTime.now();
+        request = new InternalNaturalDisqualificationApi();
+        corpRequest = new InternalCorporateDisqualificationApi();
+        InternalDisqualificationApiInternalData internal = new InternalDisqualificationApiInternalData();
+        internal.setDeltaAt(date);
+        request.setInternalData(internal);
+        corpRequest.setInternalData(internal);
+        document = new DisqualificationDocument();
+        document.setUpdated(new Updated().setAt(LocalDateTime.now()));
+        final DateTimeFormatter dateTimeFormatter =
+                DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss'Z'");
+        dateString = date.format(dateTimeFormatter);
+    }
+
+    @Test
+    public void processNaturalDisqualificationSavesDisqualification() {
+        when(repository.findUpdatedDisqualification(eq(OFFICER_ID), dateCaptor.capture())).thenReturn(new ArrayList());
+        when(repository.findById(OFFICER_ID)).thenReturn(Optional.empty());
+        when(transformer.transformNaturalDisqualifiedOfficer(OFFICER_ID, request)).thenReturn(document);
+
+        service.processNaturalDisqualification("", OFFICER_ID, request);
+
+        verify(repository).save(document);
+        assertEquals(dateString, dateCaptor.getValue());
+        assertNotNull(document.getCreated().getAt());
+    }
+
+    @Test
+    public void processNaturalDisqualificationUpdatesDisqualification() {
+        document.setCreated(new Created().setAt(LocalDateTime.now()));
+        when(repository.findUpdatedDisqualification(eq(OFFICER_ID), dateCaptor.capture())).thenReturn(new ArrayList());
+        when(repository.findById(OFFICER_ID)).thenReturn(Optional.of(document));
+        when(transformer.transformNaturalDisqualifiedOfficer(OFFICER_ID, request)).thenReturn(document);
+
+        service.processNaturalDisqualification("", OFFICER_ID, request);
+
+        verify(repository).save(document);
+        assertEquals(dateString, dateCaptor.getValue());
+        assertNotNull(document.getCreated());
+    }
+
+    @Test
+    public void processNaturalDisqualificationDoesNotSavesDisqualificationWhenUpdateAlreadyMade() {
+
+        List<DisqualificationDocument> documents = new ArrayList<>();
+        documents.add(new DisqualificationDocument());
+        when(repository.findUpdatedDisqualification(eq(OFFICER_ID), dateCaptor.capture())).thenReturn(documents);
+
+        service.processNaturalDisqualification("", OFFICER_ID, request);
+
+        verify(repository, times(0)).save(document);
+        assertEquals(dateString, dateCaptor.getValue());
+    }
+
+    @Test
+    public void processCorporateDisqualificationSavesDisqualification() {
+        when(repository.findUpdatedDisqualification(eq(OFFICER_ID), dateCaptor.capture())).thenReturn(new ArrayList());
+        when(repository.findById(OFFICER_ID)).thenReturn(Optional.empty());
+        when(transformer.transformCorporateDisqualifiedOfficer(OFFICER_ID, corpRequest)).thenReturn(document);
+
+        service.processCorporateDisqualification("", OFFICER_ID, corpRequest);
+
+        verify(repository).save(document);
+        assertEquals(dateString, dateCaptor.getValue());
+        assertNotNull(document.getCreated().getAt());
+    }
+}

--- a/src/test/java/uk/gov/companieshouse/disqualifiedofficersdataapi/transform/DisqualificationTransformerTest.java
+++ b/src/test/java/uk/gov/companieshouse/disqualifiedofficersdataapi/transform/DisqualificationTransformerTest.java
@@ -1,0 +1,90 @@
+package uk.gov.companieshouse.disqualifiedofficersdataapi.transform;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
+
+import org.junit.Before;
+import org.junit.Test;
+import uk.gov.companieshouse.api.disqualification.CorporateDisqualificationApi;
+import uk.gov.companieshouse.api.disqualification.InternalCorporateDisqualificationApi;
+import uk.gov.companieshouse.api.disqualification.InternalDisqualificationApiInternalData;
+import uk.gov.companieshouse.api.disqualification.InternalNaturalDisqualificationApi;
+import uk.gov.companieshouse.api.disqualification.NaturalDisqualificationApi;
+import uk.gov.companieshouse.disqualifiedofficersdataapi.model.CorporateDisqualificationDocument;
+import uk.gov.companieshouse.disqualifiedofficersdataapi.model.NaturalDisqualificationDocument;
+
+import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+
+public class DisqualificationTransformerTest {
+
+    private static final String OFFICER_ID = "officerId";
+    private static final String OFFICER_DISQ_ID = "officerDisqId";
+    private static final String OFFICER_DETAIL_ID = "officerDetailId";
+    private static final String OFFICER_ID_RAW = "officerIdRaw";
+
+
+    private DisqualificationTransformer transformer;
+
+    @Before
+    public void setup() {
+        transformer = new DisqualificationTransformer();
+    }
+
+    @Test
+    public void shouldTransformNaturalDisqualifiedOfficer() {
+        InternalNaturalDisqualificationApi request = new InternalNaturalDisqualificationApi();
+        NaturalDisqualificationApi external = new NaturalDisqualificationApi();
+        request.setExternalData(external);
+        InternalDisqualificationApiInternalData internal = new InternalDisqualificationApiInternalData();
+        internal.setOfficerDisqId(OFFICER_DISQ_ID);
+        internal.setOfficerDetailId(OFFICER_DETAIL_ID);
+        internal.setOfficerIdRaw(OFFICER_ID_RAW);
+        OffsetDateTime deltaAt = OffsetDateTime.of(2020, 1, 1, 1, 1, 1, 1000, ZoneOffset.MIN);
+        internal.setDeltaAt(deltaAt);
+        request.setInternalData(internal);
+
+        NaturalDisqualificationDocument document = (NaturalDisqualificationDocument) transformer
+                .transformNaturalDisqualifiedOfficer(OFFICER_ID, request);
+
+        assertEquals(OFFICER_DETAIL_ID, document.getOfficerDetailId());
+        assertEquals(OFFICER_DISQ_ID, document.getOfficerDisqId());
+        assertEquals(OFFICER_ID_RAW, document.getOfficerIdRaw());
+        assertEquals("20200101010101000001", document.getDeltaAt());
+        assertEquals(OFFICER_ID, document.getId());
+        assertFalse(document.isCorporateOfficer());
+        assertEquals(external, document.getData());
+        assertTrue(LocalDateTime.now().toEpochSecond(ZoneOffset.MIN)
+                - document.getUpdated().getAt().toEpochSecond(ZoneOffset.MIN) < 2);
+    }
+
+    @Test
+    public void shouldTransformCorporateDisqualifiedOfficer() {
+        InternalCorporateDisqualificationApi request = new InternalCorporateDisqualificationApi();
+        CorporateDisqualificationApi external = new CorporateDisqualificationApi();
+        request.setExternalData(external);
+        InternalDisqualificationApiInternalData internal = new InternalDisqualificationApiInternalData();
+        internal.setOfficerDisqId(OFFICER_DISQ_ID);
+        internal.setOfficerDetailId(OFFICER_DETAIL_ID);
+        internal.setOfficerIdRaw(OFFICER_ID_RAW);
+        OffsetDateTime deltaAt = OffsetDateTime.of(2020, 1, 1, 1, 1, 1, 1000, ZoneOffset.MIN);
+        internal.setDeltaAt(deltaAt);
+        request.setInternalData(internal);
+
+        CorporateDisqualificationDocument document = (CorporateDisqualificationDocument) transformer
+                .transformCorporateDisqualifiedOfficer(OFFICER_ID, request);
+
+        assertEquals(OFFICER_DETAIL_ID, document.getOfficerDetailId());
+        assertEquals(OFFICER_DISQ_ID, document.getOfficerDisqId());
+        assertEquals(OFFICER_ID_RAW, document.getOfficerIdRaw());
+        assertEquals("20200101010101000001", document.getDeltaAt());
+        assertEquals(OFFICER_ID, document.getId());
+        assertTrue(document.isCorporateOfficer());
+        assertEquals(external, document.getData());
+        assertTrue(LocalDateTime.now().toEpochSecond(ZoneOffset.MIN)
+                - document.getUpdated().getAt().toEpochSecond(ZoneOffset.MIN) < 2);
+    }
+
+}


### PR DESCRIPTION
This pr adds two PUT endpoints to save natural and corporate disqualified officer details in the mongo db. Also added is a healthcheck endpoint.

**Resolves:**
- DSND-583 