### PR TITLE
Add localdate serializer for saving dates in mongo

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
 
         <!-- Internal -->
         <structured-logging.version>1.9.12</structured-logging.version>
-        <private-api-sdk-java.version>2.0.141</private-api-sdk-java.version>
+        <private-api-sdk-java.version>2.0.146</private-api-sdk-java.version>
         <api-sdk-manager-java-library.version>1.0.4</api-sdk-manager-java-library.version>
         <api-helper-java-library.version>1.4.5</api-helper-java-library.version>
         

--- a/src/main/java/uk/gov/companieshouse/disqualifiedofficersdataapi/config/ApplicationConfig.java
+++ b/src/main/java/uk/gov/companieshouse/disqualifiedofficersdataapi/config/ApplicationConfig.java
@@ -1,32 +1,61 @@
 package uk.gov.companieshouse.disqualifiedofficersdataapi.config;
 
-import org.springframework.beans.factory.annotation.Autowired;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+import org.springframework.beans.factory.config.ConfigurableBeanFactory;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.data.mongodb.core.convert.DefaultMongoTypeMapper;
-import org.springframework.data.mongodb.core.convert.MappingMongoConverter;
+import org.springframework.context.annotation.Scope;
+import org.springframework.data.mongodb.core.convert.MongoCustomConversions;
+import uk.gov.companieshouse.api.InternalApiClient;
+import uk.gov.companieshouse.disqualifiedofficersdataapi.converter.DisqualifiedOfficerWriteConverter;
+import uk.gov.companieshouse.disqualifiedofficersdataapi.serialization.LocalDateSerializer;
 import uk.gov.companieshouse.environment.EnvironmentReader;
 import uk.gov.companieshouse.environment.impl.EnvironmentReaderImpl;
+import uk.gov.companieshouse.sdk.manager.ApiSdkManager;
 
-import javax.annotation.PostConstruct;
+import java.time.LocalDate;
+import java.util.List;
 
 @Configuration
 public class ApplicationConfig {
-    
-    @Autowired
-    private MappingMongoConverter mappingMongoConverter;
 
     @Bean
     EnvironmentReader environmentReader() {
         return new EnvironmentReaderImpl();
     }
 
+    @Bean
+    @Scope(ConfigurableBeanFactory.SCOPE_PROTOTYPE)
+    public InternalApiClient internalApiClient() {
+        return ApiSdkManager.getPrivateSDK();
+    }
 
     /**
-     * Converter to remove _class from the mongo record during saving
+     * mongoCustomConversions.
+     *
+     * @return MongoCustomConversions.
      */
-    @PostConstruct
-    public void createConverterToRemoveClassName() {
-        mappingMongoConverter.setTypeMapper(new DefaultMongoTypeMapper(null));
+    @Bean
+    public MongoCustomConversions mongoCustomConversions() {
+        ObjectMapper objectMapper = mongoDbObjectMapper();
+        return new MongoCustomConversions(List.of(new DisqualifiedOfficerWriteConverter(objectMapper)));
+    }
+
+    /**
+     * Mongo DB Object Mapper.
+     *
+     * @return ObjectMapper.
+     */
+    private ObjectMapper mongoDbObjectMapper() {
+        ObjectMapper objectMapper = new ObjectMapper();
+        objectMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+        objectMapper.configure(SerializationFeature.FAIL_ON_EMPTY_BEANS, false);
+        SimpleModule module = new SimpleModule();
+        module.addSerializer(LocalDate.class, new LocalDateSerializer());
+        objectMapper.registerModule(module);
+        return objectMapper;
     }
 }

--- a/src/main/java/uk/gov/companieshouse/disqualifiedofficersdataapi/config/ApplicationConfig.java
+++ b/src/main/java/uk/gov/companieshouse/disqualifiedofficersdataapi/config/ApplicationConfig.java
@@ -22,17 +22,6 @@ import java.util.List;
 @Configuration
 public class ApplicationConfig {
 
-    @Bean
-    EnvironmentReader environmentReader() {
-        return new EnvironmentReaderImpl();
-    }
-
-    @Bean
-    @Scope(ConfigurableBeanFactory.SCOPE_PROTOTYPE)
-    public InternalApiClient internalApiClient() {
-        return ApiSdkManager.getPrivateSDK();
-    }
-
     /**
      * mongoCustomConversions.
      *

--- a/src/main/java/uk/gov/companieshouse/disqualifiedofficersdataapi/converter/DisqualifiedOfficerWriteConverter.java
+++ b/src/main/java/uk/gov/companieshouse/disqualifiedofficersdataapi/converter/DisqualifiedOfficerWriteConverter.java
@@ -1,0 +1,31 @@
+package uk.gov.companieshouse.disqualifiedofficersdataapi.converter;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.mongodb.BasicDBObject;
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.data.convert.WritingConverter;
+import uk.gov.companieshouse.disqualifiedofficersdataapi.model.DisqualificationDocument;
+
+@WritingConverter
+public class DisqualifiedOfficerWriteConverter implements Converter<DisqualificationDocument, BasicDBObject> {
+
+    private final ObjectMapper objectMapper;
+
+    public DisqualifiedOfficerWriteConverter(ObjectMapper objectMapper) {
+        this.objectMapper = objectMapper;
+    }
+
+    /**
+     * Write convertor.
+     * @param source source Document.
+     * @return charge BSON object.
+     */
+    @Override
+    public BasicDBObject convert(DisqualificationDocument source) {
+        try {
+            return BasicDBObject.parse(objectMapper.writeValueAsString(source));
+        } catch (Exception ex) {
+            throw new RuntimeException(ex);
+        }
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/disqualifiedofficersdataapi/serialization/LocalDateSerializer.java
+++ b/src/main/java/uk/gov/companieshouse/disqualifiedofficersdataapi/serialization/LocalDateSerializer.java
@@ -1,0 +1,25 @@
+package uk.gov.companieshouse.disqualifiedofficersdataapi.serialization;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.SerializerProvider;
+
+import java.io.IOException;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+
+public class LocalDateSerializer extends JsonSerializer<LocalDate> {
+
+    @Override
+    public void serialize(LocalDate localDate, JsonGenerator jsonGenerator,
+                          SerializerProvider serializerProvider) throws IOException {
+        if (localDate == null) {
+            jsonGenerator.writeNull();
+        } else {
+            DateTimeFormatter dateTimeFormatter =
+                    DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'");
+            String format = localDate.atStartOfDay().format(dateTimeFormatter);
+            jsonGenerator.writeRawValue("ISODate(\"" + format + "\")");
+        }
+    }
+}

--- a/src/test/java/uk/gov/companieshouse/disqualifiedofficersdataapi/converter/DisqualifiedOfficerWriteConverterTest.java
+++ b/src/test/java/uk/gov/companieshouse/disqualifiedofficersdataapi/converter/DisqualifiedOfficerWriteConverterTest.java
@@ -1,0 +1,32 @@
+package uk.gov.companieshouse.disqualifiedofficersdataapi.converter;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.mongodb.BasicDBObject;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import uk.gov.companieshouse.disqualifiedofficersdataapi.model.DisqualificationDocument;
+
+import static org.junit.Assert.assertTrue;
+
+public class DisqualifiedOfficerWriteConverterTest {
+
+    private static final String OFFICER_ID = "officerId";
+
+    private DisqualifiedOfficerWriteConverter converter;
+
+    @BeforeEach
+    public void setUp() {
+        converter = new DisqualifiedOfficerWriteConverter(new ObjectMapper());
+    }
+
+    @Test
+    public void canConvertDocument() {
+        DisqualificationDocument document = new DisqualificationDocument();
+        document.setId("OFFICER_ID");
+
+        BasicDBObject object = converter.convert(document);
+
+        String json = object.toJson();
+        assertTrue(json.contains(OFFICER_ID));
+    }
+}

--- a/src/test/java/uk/gov/companieshouse/disqualifiedofficersdataapi/serialization/LocalDateSerializerTest.java
+++ b/src/test/java/uk/gov/companieshouse/disqualifiedofficersdataapi/serialization/LocalDateSerializerTest.java
@@ -1,0 +1,42 @@
+package uk.gov.companieshouse.disqualifiedofficersdataapi.serialization;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDate;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+public class LocalDateSerializerTest {
+
+    private LocalDateSerializer serializer;
+
+    @Mock
+    private JsonGenerator generator;
+
+    @Captor
+    private ArgumentCaptor<String> dateString;
+
+    @BeforeEach
+    public void setUp() {
+        serializer = new LocalDateSerializer();
+    }
+
+    @Test
+    public void dateShouldSerialize() throws Exception {
+        LocalDate date = LocalDate.of(2020, 1, 1);
+
+        serializer.serialize(date, generator, null);
+
+        verify(generator).writeRawValue(dateString.capture());
+        assertEquals(dateString.getValue(), "ISODate(\"2020-01-01T00:00:00.000Z\")");
+    }
+}

--- a/src/test/java/uk/gov/companieshouse/disqualifiedofficersdataapi/service/DisqualifiedOfficerServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/disqualifiedofficersdataapi/service/DisqualifiedOfficerServiceTest.java
@@ -13,7 +13,6 @@ import uk.gov.companieshouse.api.disqualification.InternalDisqualificationApiInt
 import uk.gov.companieshouse.api.disqualification.InternalNaturalDisqualificationApi;
 import uk.gov.companieshouse.disqualifiedofficersdataapi.model.Created;
 import uk.gov.companieshouse.disqualifiedofficersdataapi.model.DisqualificationDocument;
-import uk.gov.companieshouse.disqualifiedofficersdataapi.model.NaturalDisqualificationDocument;
 import uk.gov.companieshouse.disqualifiedofficersdataapi.model.Updated;
 import uk.gov.companieshouse.disqualifiedofficersdataapi.repository.DisqualifiedOfficerRepository;
 import uk.gov.companieshouse.disqualifiedofficersdataapi.transform.DisqualificationTransformer;
@@ -25,7 +24,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
-import static com.mongodb.assertions.Assertions.assertNull;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.mockito.ArgumentMatchers.eq;


### PR DESCRIPTION
This pr adds a local date serializer class that converts local dates to ISO dates when objects are saved to the mongo database. This is to avoid an issue where dates were being saved as at 11pm the night before. This has been configured with a write converter class.

**Required for:**
- DSND-583