### PR TITLE
Change converter to use api sub classes

### DIFF
--- a/src/main/java/uk/gov/companieshouse/disqualifiedofficersdataapi/config/ApplicationConfig.java
+++ b/src/main/java/uk/gov/companieshouse/disqualifiedofficersdataapi/config/ApplicationConfig.java
@@ -1,20 +1,16 @@
 package uk.gov.companieshouse.disqualifiedofficersdataapi.config;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.databind.module.SimpleModule;
-import org.springframework.beans.factory.config.ConfigurableBeanFactory;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.Scope;
 import org.springframework.data.mongodb.core.convert.MongoCustomConversions;
-import uk.gov.companieshouse.api.InternalApiClient;
-import uk.gov.companieshouse.disqualifiedofficersdataapi.converter.DisqualifiedOfficerWriteConverter;
+import uk.gov.companieshouse.disqualifiedofficersdataapi.converter.DisqualifiedCorporateOfficerWriteConverter;
+import uk.gov.companieshouse.disqualifiedofficersdataapi.converter.DisqualifiedNaturalOfficerWriteConverter;
 import uk.gov.companieshouse.disqualifiedofficersdataapi.serialization.LocalDateSerializer;
-import uk.gov.companieshouse.environment.EnvironmentReader;
-import uk.gov.companieshouse.environment.impl.EnvironmentReaderImpl;
-import uk.gov.companieshouse.sdk.manager.ApiSdkManager;
 
 import java.time.LocalDate;
 import java.util.List;
@@ -30,7 +26,8 @@ public class ApplicationConfig {
     @Bean
     public MongoCustomConversions mongoCustomConversions() {
         ObjectMapper objectMapper = mongoDbObjectMapper();
-        return new MongoCustomConversions(List.of(new DisqualifiedOfficerWriteConverter(objectMapper)));
+        return new MongoCustomConversions(List.of(new DisqualifiedNaturalOfficerWriteConverter(objectMapper),
+                new DisqualifiedCorporateOfficerWriteConverter(objectMapper)));
     }
 
     /**
@@ -42,6 +39,7 @@ public class ApplicationConfig {
         ObjectMapper objectMapper = new ObjectMapper();
         objectMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
         objectMapper.configure(SerializationFeature.FAIL_ON_EMPTY_BEANS, false);
+        objectMapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
         SimpleModule module = new SimpleModule();
         module.addSerializer(LocalDate.class, new LocalDateSerializer());
         objectMapper.registerModule(module);

--- a/src/main/java/uk/gov/companieshouse/disqualifiedofficersdataapi/config/MongoDbConfig.java
+++ b/src/main/java/uk/gov/companieshouse/disqualifiedofficersdataapi/config/MongoDbConfig.java
@@ -1,0 +1,22 @@
+package uk.gov.companieshouse.disqualifiedofficersdataapi.config;
+
+import org.springframework.beans.factory.InitializingBean;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Lazy;
+import org.springframework.data.mongodb.core.convert.DefaultMongoTypeMapper;
+import org.springframework.data.mongodb.core.convert.MappingMongoConverter;
+
+@Configuration
+public class MongoDbConfig implements InitializingBean {
+
+    @Autowired
+    @Lazy
+    private MappingMongoConverter mappingMongoConverter;
+
+    // Remove _class field from data
+    @Override
+    public void afterPropertiesSet() {
+        mappingMongoConverter.setTypeMapper(new DefaultMongoTypeMapper(null));
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/disqualifiedofficersdataapi/converter/DisqualifiedCorporateOfficerWriteConverter.java
+++ b/src/main/java/uk/gov/companieshouse/disqualifiedofficersdataapi/converter/DisqualifiedCorporateOfficerWriteConverter.java
@@ -1,0 +1,37 @@
+package uk.gov.companieshouse.disqualifiedofficersdataapi.converter;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.mongodb.BasicDBObject;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.data.convert.WritingConverter;
+import uk.gov.companieshouse.api.disqualification.CorporateDisqualificationApi;
+import uk.gov.companieshouse.api.disqualification.NaturalDisqualificationApi;
+import uk.gov.companieshouse.logging.Logger;
+
+@WritingConverter
+public class DisqualifiedCorporateOfficerWriteConverter implements Converter<CorporateDisqualificationApi, BasicDBObject> {
+
+    private final ObjectMapper objectMapper;
+
+    @Autowired
+    private Logger logger;
+
+    public DisqualifiedCorporateOfficerWriteConverter(ObjectMapper objectMapper) {
+        this.objectMapper = objectMapper;
+    }
+
+    /**
+     * Write convertor.
+     * @param source source Document.
+     * @return charge BSON object.
+     */
+    @Override
+    public BasicDBObject convert(CorporateDisqualificationApi source) {
+        try {
+            return BasicDBObject.parse(objectMapper.writeValueAsString(source));
+        } catch (Exception ex) {
+            throw new RuntimeException("Error is here: " + ex.getMessage());
+        }
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/disqualifiedofficersdataapi/converter/DisqualifiedCorporateOfficerWriteConverter.java
+++ b/src/main/java/uk/gov/companieshouse/disqualifiedofficersdataapi/converter/DisqualifiedCorporateOfficerWriteConverter.java
@@ -2,20 +2,14 @@ package uk.gov.companieshouse.disqualifiedofficersdataapi.converter;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.mongodb.BasicDBObject;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.convert.converter.Converter;
 import org.springframework.data.convert.WritingConverter;
 import uk.gov.companieshouse.api.disqualification.CorporateDisqualificationApi;
-import uk.gov.companieshouse.api.disqualification.NaturalDisqualificationApi;
-import uk.gov.companieshouse.logging.Logger;
 
 @WritingConverter
 public class DisqualifiedCorporateOfficerWriteConverter implements Converter<CorporateDisqualificationApi, BasicDBObject> {
 
     private final ObjectMapper objectMapper;
-
-    @Autowired
-    private Logger logger;
 
     public DisqualifiedCorporateOfficerWriteConverter(ObjectMapper objectMapper) {
         this.objectMapper = objectMapper;
@@ -31,7 +25,7 @@ public class DisqualifiedCorporateOfficerWriteConverter implements Converter<Cor
         try {
             return BasicDBObject.parse(objectMapper.writeValueAsString(source));
         } catch (Exception ex) {
-            throw new RuntimeException("Error is here: " + ex.getMessage());
+            throw new RuntimeException(ex);
         }
     }
 }

--- a/src/main/java/uk/gov/companieshouse/disqualifiedofficersdataapi/converter/DisqualifiedNaturalOfficerWriteConverter.java
+++ b/src/main/java/uk/gov/companieshouse/disqualifiedofficersdataapi/converter/DisqualifiedNaturalOfficerWriteConverter.java
@@ -2,21 +2,14 @@ package uk.gov.companieshouse.disqualifiedofficersdataapi.converter;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.mongodb.BasicDBObject;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.convert.converter.Converter;
 import org.springframework.data.convert.WritingConverter;
 import uk.gov.companieshouse.api.disqualification.NaturalDisqualificationApi;
-import uk.gov.companieshouse.disqualifiedofficersdataapi.model.DisqualificationDocument;
-import uk.gov.companieshouse.disqualifiedofficersdataapi.model.NaturalDisqualificationDocument;
-import uk.gov.companieshouse.logging.Logger;
 
 @WritingConverter
 public class DisqualifiedNaturalOfficerWriteConverter implements Converter<NaturalDisqualificationApi, BasicDBObject> {
 
     private final ObjectMapper objectMapper;
-
-    @Autowired
-    private Logger logger;
 
     public DisqualifiedNaturalOfficerWriteConverter(ObjectMapper objectMapper) {
         this.objectMapper = objectMapper;
@@ -32,7 +25,7 @@ public class DisqualifiedNaturalOfficerWriteConverter implements Converter<Natur
         try {
             return BasicDBObject.parse(objectMapper.writeValueAsString(source));
         } catch (Exception ex) {
-            throw new RuntimeException("Error is here: " + ex.getMessage());
+            throw new RuntimeException(ex);
         }
     }
 }

--- a/src/main/java/uk/gov/companieshouse/disqualifiedofficersdataapi/converter/DisqualifiedNaturalOfficerWriteConverter.java
+++ b/src/main/java/uk/gov/companieshouse/disqualifiedofficersdataapi/converter/DisqualifiedNaturalOfficerWriteConverter.java
@@ -2,16 +2,23 @@ package uk.gov.companieshouse.disqualifiedofficersdataapi.converter;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.mongodb.BasicDBObject;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.convert.converter.Converter;
 import org.springframework.data.convert.WritingConverter;
+import uk.gov.companieshouse.api.disqualification.NaturalDisqualificationApi;
 import uk.gov.companieshouse.disqualifiedofficersdataapi.model.DisqualificationDocument;
+import uk.gov.companieshouse.disqualifiedofficersdataapi.model.NaturalDisqualificationDocument;
+import uk.gov.companieshouse.logging.Logger;
 
 @WritingConverter
-public class DisqualifiedOfficerWriteConverter implements Converter<DisqualificationDocument, BasicDBObject> {
+public class DisqualifiedNaturalOfficerWriteConverter implements Converter<NaturalDisqualificationApi, BasicDBObject> {
 
     private final ObjectMapper objectMapper;
 
-    public DisqualifiedOfficerWriteConverter(ObjectMapper objectMapper) {
+    @Autowired
+    private Logger logger;
+
+    public DisqualifiedNaturalOfficerWriteConverter(ObjectMapper objectMapper) {
         this.objectMapper = objectMapper;
     }
 
@@ -21,11 +28,11 @@ public class DisqualifiedOfficerWriteConverter implements Converter<Disqualifica
      * @return charge BSON object.
      */
     @Override
-    public BasicDBObject convert(DisqualificationDocument source) {
+    public BasicDBObject convert(NaturalDisqualificationApi source) {
         try {
             return BasicDBObject.parse(objectMapper.writeValueAsString(source));
         } catch (Exception ex) {
-            throw new RuntimeException(ex);
+            throw new RuntimeException("Error is here: " + ex.getMessage());
         }
     }
 }

--- a/src/main/java/uk/gov/companieshouse/disqualifiedofficersdataapi/serialization/LocalDateSerializer.java
+++ b/src/main/java/uk/gov/companieshouse/disqualifiedofficersdataapi/serialization/LocalDateSerializer.java
@@ -17,7 +17,7 @@ public class LocalDateSerializer extends JsonSerializer<LocalDate> {
             jsonGenerator.writeNull();
         } else {
             DateTimeFormatter dateTimeFormatter =
-                    DateTimeFormatter.ofPattern("yyyy-MM-ddTHH:mm:ss.SSSZ");
+                    DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'");
             String format = localDate.atStartOfDay().format(dateTimeFormatter);
             jsonGenerator.writeRawValue("ISODate(\"" + format + "\")");
         }

--- a/src/test/java/uk/gov/companieshouse/disqualifiedofficersdataapi/converter/DisqualifiedCorporateOfficerWriteConverterTest.java
+++ b/src/test/java/uk/gov/companieshouse/disqualifiedofficersdataapi/converter/DisqualifiedCorporateOfficerWriteConverterTest.java
@@ -4,27 +4,27 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.mongodb.BasicDBObject;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import uk.gov.companieshouse.disqualifiedofficersdataapi.model.DisqualificationDocument;
+import uk.gov.companieshouse.api.disqualification.CorporateDisqualificationApi;
 
 import static org.junit.Assert.assertTrue;
 
-public class DisqualifiedOfficerWriteConverterTest {
+public class DisqualifiedCorporateOfficerWriteConverterTest {
 
     private static final String OFFICER_ID = "officerId";
 
-    private DisqualifiedOfficerWriteConverter converter;
+    private DisqualifiedCorporateOfficerWriteConverter converter;
 
     @BeforeEach
     public void setUp() {
-        converter = new DisqualifiedOfficerWriteConverter(new ObjectMapper());
+        converter = new DisqualifiedCorporateOfficerWriteConverter(new ObjectMapper());
     }
 
     @Test
     public void canConvertDocument() {
-        DisqualificationDocument document = new DisqualificationDocument();
-        document.setId("OFFICER_ID");
+        CorporateDisqualificationApi api = new CorporateDisqualificationApi();
+        api.setCompanyNumber(OFFICER_ID);
 
-        BasicDBObject object = converter.convert(document);
+        BasicDBObject object = converter.convert(api);
 
         String json = object.toJson();
         assertTrue(json.contains(OFFICER_ID));

--- a/src/test/java/uk/gov/companieshouse/disqualifiedofficersdataapi/converter/DisqualifiedNaturalOfficerWriteConverterTest.java
+++ b/src/test/java/uk/gov/companieshouse/disqualifiedofficersdataapi/converter/DisqualifiedNaturalOfficerWriteConverterTest.java
@@ -1,0 +1,33 @@
+package uk.gov.companieshouse.disqualifiedofficersdataapi.converter;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.mongodb.BasicDBObject;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import uk.gov.companieshouse.api.disqualification.NaturalDisqualificationApi;
+import uk.gov.companieshouse.disqualifiedofficersdataapi.model.DisqualificationDocument;
+
+import static org.junit.Assert.assertTrue;
+
+public class DisqualifiedNaturalOfficerWriteConverterTest {
+
+    private static final String OFFICER_ID = "officerId";
+
+    private DisqualifiedNaturalOfficerWriteConverter converter;
+
+    @BeforeEach
+    public void setUp() {
+        converter = new DisqualifiedNaturalOfficerWriteConverter(new ObjectMapper());
+    }
+
+    @Test
+    public void canConvertDocument() {
+        NaturalDisqualificationApi api = new NaturalDisqualificationApi();
+        api.setPersonNumber(OFFICER_ID);
+
+        BasicDBObject object = converter.convert(api);
+
+        String json = object.toJson();
+        assertTrue(json.contains(OFFICER_ID));
+    }
+}


### PR DESCRIPTION
This pr fixes a bug that stopped the converter being called. The converters now convert the api sub classes of the document individually meaning the local date should be transformed correctly.