### PR TITLE
Add functionality to call CHS Kafka api

### DIFF
--- a/src/main/java/uk/gov/companieshouse/disqualifiedofficersdataapi/api/ApiClientService.java
+++ b/src/main/java/uk/gov/companieshouse/disqualifiedofficersdataapi/api/ApiClientService.java
@@ -1,0 +1,14 @@
+package uk.gov.companieshouse.disqualifiedofficersdataapi.api;
+
+import org.springframework.stereotype.Component;
+import uk.gov.companieshouse.api.InternalApiClient;
+import uk.gov.companieshouse.sdk.manager.ApiSdkManager;
+
+@Component
+public class ApiClientService {
+
+    public InternalApiClient getInternalApiClient() {
+        return ApiSdkManager.getPrivateSDK();
+    }
+
+}

--- a/src/main/java/uk/gov/companieshouse/disqualifiedofficersdataapi/api/DisqualifiedOfficerApiService.java
+++ b/src/main/java/uk/gov/companieshouse/disqualifiedofficersdataapi/api/DisqualifiedOfficerApiService.java
@@ -24,7 +24,7 @@ public class DisqualifiedOfficerApiService {
     private final ApiClientService apiClientService;
 
     /**
-     * Invoke Insolvency API.
+     * Invoke API.
      */
     public DisqualifiedOfficerApiService(@Value("${chs.kafka.api.endpoint}") String chsKafkaUrl,
                                 ApiClientService apiClientService, Logger logger) {

--- a/src/main/java/uk/gov/companieshouse/disqualifiedofficersdataapi/api/DisqualifiedOfficerApiService.java
+++ b/src/main/java/uk/gov/companieshouse/disqualifiedofficersdataapi/api/DisqualifiedOfficerApiService.java
@@ -1,0 +1,84 @@
+package uk.gov.companieshouse.disqualifiedofficersdataapi.api;
+
+import java.time.OffsetDateTime;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import uk.gov.companieshouse.api.InternalApiClient;
+import uk.gov.companieshouse.api.chskafka.ChangedResource;
+import uk.gov.companieshouse.api.chskafka.ChangedResourceEvent;
+import uk.gov.companieshouse.api.error.ApiErrorResponseException;
+import uk.gov.companieshouse.api.handler.chskafka.request.PrivateChangedResourcePost;
+import uk.gov.companieshouse.api.model.ApiResponse;
+import uk.gov.companieshouse.disqualifiedofficersdataapi.exceptions.MethodNotAllowedException;
+import uk.gov.companieshouse.disqualifiedofficersdataapi.exceptions.ServiceUnavailableException;
+import uk.gov.companieshouse.logging.Logger;
+
+@Service
+public class DisqualifiedOfficerApiService {
+
+    private static final String CHANGED_RESOURCE_URI = "/resource-changed";
+    private final Logger logger;
+    private final String chsKafkaUrl;
+    private final ApiClientService apiClientService;
+
+    /**
+     * Invoke Insolvency API.
+     */
+    public DisqualifiedOfficerApiService(@Value("${chs.kafka.api.endpoint}") String chsKafkaUrl,
+                                ApiClientService apiClientService, Logger logger) {
+        this.chsKafkaUrl = chsKafkaUrl;
+        this.apiClientService = apiClientService;
+        this.logger = logger;
+    }
+
+    /**
+     * Calls the CHS Kafka api.
+     * @param contextId the kafka context id
+     * @param officerId the officer id for the record in question
+     * @param type the type of officer, corporate or natural disqualified
+     * @return the respons from the kafka api
+     */
+    public ApiResponse<Void> invokeChsKafkaApi(String contextId, String officerId, String type) {
+        InternalApiClient internalApiClient = apiClientService.getInternalApiClient();
+        internalApiClient.setBasePath(chsKafkaUrl);
+
+        PrivateChangedResourcePost changedResourcePost =
+                internalApiClient.privateChangedResourceHandler().postChangedResource(
+                        CHANGED_RESOURCE_URI, mapChangedResource(contextId, officerId, type));
+
+        try {
+            return changedResourcePost.execute();
+        } catch (ApiErrorResponseException exp) {
+            HttpStatus statusCode = HttpStatus.valueOf(exp.getStatusCode());
+            if (!statusCode.is2xxSuccessful() && statusCode != HttpStatus.SERVICE_UNAVAILABLE) {
+                logger.error("Unsuccessful call to /resource-changed endpoint", exp);
+                throw new MethodNotAllowedException(exp.getMessage());
+            } else if (statusCode == HttpStatus.SERVICE_UNAVAILABLE) {
+                logger.error("Service unavailable while calling /resource-changed endpoint", exp);
+                throw new ServiceUnavailableException(exp.getMessage());
+            } else {
+                logger.error("Error occurred while calling /resource-changed endpoint", exp);
+                throw new RuntimeException(exp);
+            }
+        }
+    }
+
+    private ChangedResource mapChangedResource(String contextId, String officerId, String officerType) {
+        String resourceUri = "/disqualified-officers/" + officerType + "/" + officerId;
+
+        ChangedResourceEvent event = new ChangedResourceEvent();
+        event.setType("changed");
+        event.publishedAt(String.valueOf(OffsetDateTime.now()));
+
+        ChangedResource changedResource = new ChangedResource();
+        changedResource.setResourceUri(resourceUri);
+        changedResource.event(event);
+        changedResource.setResourceKind("disqualified-officers");
+        changedResource.setContextId(contextId);
+
+        return changedResource;
+    }
+
+}

--- a/src/main/java/uk/gov/companieshouse/disqualifiedofficersdataapi/config/ExceptionHandlerConfig.java
+++ b/src/main/java/uk/gov/companieshouse/disqualifiedofficersdataapi/config/ExceptionHandlerConfig.java
@@ -1,0 +1,107 @@
+package uk.gov.companieshouse.disqualifiedofficersdataapi.config;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeParseException;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.context.request.WebRequest;
+
+import uk.gov.companieshouse.disqualifiedofficersdataapi.exceptions.BadRequestException;
+import uk.gov.companieshouse.disqualifiedofficersdataapi.exceptions.MethodNotAllowedException;
+import uk.gov.companieshouse.disqualifiedofficersdataapi.exceptions.ServiceUnavailableException;
+import uk.gov.companieshouse.logging.Logger;
+
+@ControllerAdvice
+public class ExceptionHandlerConfig {
+    private final Logger logger;
+
+    @Autowired
+    public ExceptionHandlerConfig(Logger logger) {
+        this.logger = logger;
+    }
+
+    /**
+     * Runtime exception handler. Acts as the catch-all scenario.
+     *
+     * @param ex      exception to handle.
+     * @param request request.
+     * @return error response to return.
+     */
+    @ExceptionHandler(value = {Exception.class})
+    public ResponseEntity<Object> handleException(Exception ex, WebRequest request) {
+        logger.error(String.format("Unexpected exception, response code: %s",
+                HttpStatus.INTERNAL_SERVER_ERROR), ex);
+
+        Map<String, Object> responseBody = new LinkedHashMap<>();
+        responseBody.put("timestamp", LocalDateTime.now());
+        responseBody.put("message", "Unable to process the request.");
+        request.setAttribute("javax.servlet.error.exception", ex, 0);
+        return new ResponseEntity(responseBody, HttpStatus.INTERNAL_SERVER_ERROR);
+    }
+
+    /**
+     * MethodNotAllowedException exception handler.
+     *
+     * @param ex      exception to handle.
+     * @param request request.
+     * @return error response to return.
+     */
+    @ExceptionHandler(value = {MethodNotAllowedException.class})
+    public ResponseEntity<Object> handleMethodNotAllowedException(Exception ex,
+                                                                  WebRequest request) {
+        logger.error(String.format("Unable to process the request, response code: %s",
+                HttpStatus.METHOD_NOT_ALLOWED), ex);
+
+        Map<String, Object> responseBody = new LinkedHashMap<>();
+        responseBody.put("timestamp", LocalDateTime.now());
+        responseBody.put("message", "Unable to process the request.");
+        request.setAttribute("javax.servlet.error.exception", ex, 0);
+        return new ResponseEntity(responseBody, HttpStatus.METHOD_NOT_ALLOWED);
+    }
+
+    /**
+     * ServiceUnavailableException exception handler.
+     * To be thrown when there are connection issues.
+     *
+     * @param ex      exception to handle.
+     * @param request request.
+     * @return error response to return.
+     */
+    @ExceptionHandler(value = {ServiceUnavailableException.class})
+    public ResponseEntity<Object> handleServiceUnavailableException(Exception ex,
+                                                                    WebRequest request) {
+        logger.error(String.format("Service unavailable, response code: %s",
+                HttpStatus.SERVICE_UNAVAILABLE), ex);
+
+        Map<String, Object> responseBody = new LinkedHashMap<>();
+        responseBody.put("timestamp", LocalDateTime.now());
+        responseBody.put("message", "Service unavailable.");
+        request.setAttribute("javax.servlet.error.exception", ex, 0);
+        return new ResponseEntity(responseBody, HttpStatus.SERVICE_UNAVAILABLE);
+    }
+
+    /**
+     * BadRequestException exception handler.
+     * Thrown when data is given in the wrong format.
+     *
+     * @param ex      exception to handle.
+     * @param request request.
+     * @return error response to return.
+     */
+    @ExceptionHandler(value = {BadRequestException.class, DateTimeParseException.class})
+    public ResponseEntity<Object> handleBadRequestException(Exception ex, WebRequest request) {
+        logger.error(String.format("Bad request, response code: %s", HttpStatus.BAD_REQUEST), ex);
+
+        Map<String, Object> responseBody = new LinkedHashMap<>();
+        responseBody.put("timestamp", LocalDateTime.now());
+        responseBody.put("message", "Bad request.");
+        request.setAttribute("javax.servlet.error.exception", ex, 0);
+        return new ResponseEntity(responseBody, HttpStatus.BAD_REQUEST);
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/disqualifiedofficersdataapi/exceptions/BadRequestException.java
+++ b/src/main/java/uk/gov/companieshouse/disqualifiedofficersdataapi/exceptions/BadRequestException.java
@@ -1,0 +1,7 @@
+package uk.gov.companieshouse.disqualifiedofficersdataapi.exceptions;
+
+public class BadRequestException extends RuntimeException {
+    public BadRequestException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/disqualifiedofficersdataapi/exceptions/MethodNotAllowedException.java
+++ b/src/main/java/uk/gov/companieshouse/disqualifiedofficersdataapi/exceptions/MethodNotAllowedException.java
@@ -1,0 +1,7 @@
+package uk.gov.companieshouse.disqualifiedofficersdataapi.exceptions;
+
+public class MethodNotAllowedException extends RuntimeException {
+    public MethodNotAllowedException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/disqualifiedofficersdataapi/exceptions/ServiceUnavailableException.java
+++ b/src/main/java/uk/gov/companieshouse/disqualifiedofficersdataapi/exceptions/ServiceUnavailableException.java
@@ -1,0 +1,7 @@
+package uk.gov.companieshouse.disqualifiedofficersdataapi.exceptions;
+
+public class ServiceUnavailableException extends RuntimeException {
+    public ServiceUnavailableException(String message) {
+        super(message);
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -5,6 +5,12 @@ management:
       path-mapping:
         health: /healthcheck
 
+chs:
+  kafka:
+    api:
+      endpoint: ${CHS_KAFKA_API_URL:localhost}
+      key: ${CHS_API_KEY:chsApiKey}
+
 logger:
   namespace: disqualified-officer-data-api
 

--- a/src/test/java/uk/gov/companieshouse/disqualifiedofficersdataapi/api/DisqualifiedOfficerApiClientServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/disqualifiedofficersdataapi/api/DisqualifiedOfficerApiClientServiceTest.java
@@ -27,7 +27,7 @@ import java.util.stream.Stream;
 import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
-public class InsolvencyApiClientServiceTest {
+public class DisqualifiedOfficerApiClientServiceTest {
 
     @Mock
     private ApiClientService apiClientService;

--- a/src/test/java/uk/gov/companieshouse/disqualifiedofficersdataapi/api/InsolvencyApiClientServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/disqualifiedofficersdataapi/api/InsolvencyApiClientServiceTest.java
@@ -1,0 +1,123 @@
+package uk.gov.companieshouse.disqualifiedofficersdataapi.api;
+
+import com.google.api.client.http.HttpHeaders;
+import com.google.api.client.http.HttpResponseException;
+import org.assertj.core.api.Assertions;
+import org.junit.Assert;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.companieshouse.api.InternalApiClient;
+import uk.gov.companieshouse.api.error.ApiErrorResponseException;
+import uk.gov.companieshouse.api.handler.chskafka.PrivateChangedResourceHandler;
+import uk.gov.companieshouse.api.handler.chskafka.request.PrivateChangedResourcePost;
+import uk.gov.companieshouse.api.model.ApiResponse;
+import uk.gov.companieshouse.disqualifiedofficersdataapi.exceptions.MethodNotAllowedException;
+import uk.gov.companieshouse.disqualifiedofficersdataapi.exceptions.ServiceUnavailableException;
+import uk.gov.companieshouse.logging.Logger;
+
+import java.util.stream.Stream;
+
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+public class InsolvencyApiClientServiceTest {
+
+    @Mock
+    private ApiClientService apiClientService;
+
+    @Mock
+    private InternalApiClient internalApiClient;
+
+    @Mock
+    private PrivateChangedResourceHandler privateChangedResourceHandler;
+
+    @Mock
+    private PrivateChangedResourcePost changedResourcePost;
+
+    @Mock
+    private ApiResponse<Void> response;
+
+    @Mock
+    private Logger logger;
+
+    @InjectMocks
+    private DisqualifiedOfficerApiService disqualifiedOfficerApiService;
+
+    @Test
+    void should_invoke_chs_kafka_endpoint_successfully() throws ApiErrorResponseException {
+
+        when(apiClientService.getInternalApiClient()).thenReturn(internalApiClient);
+        when(internalApiClient.privateChangedResourceHandler()).thenReturn(privateChangedResourceHandler);
+        when(privateChangedResourceHandler.postChangedResource(Mockito.any(), Mockito.any())).thenReturn(changedResourcePost);
+        when(changedResourcePost.execute()).thenReturn(response);
+
+        ApiResponse<?> apiResponse = disqualifiedOfficerApiService.invokeChsKafkaApi("35234234",
+                "CH4000056", "natural");
+
+        Assertions.assertThat(apiResponse).isNotNull();
+
+        verify(apiClientService, times(1)).getInternalApiClient();
+        verify(internalApiClient, times(1)).privateChangedResourceHandler();
+        verify(privateChangedResourceHandler, times(1)).postChangedResource(Mockito.any(),
+                Mockito.any());
+        verify(changedResourcePost, times(1)).execute();
+    }
+
+    @Test
+    void should_handle_exception_when_chs_kafka_endpoint_throws_exception() throws ApiErrorResponseException {
+
+        when(apiClientService.getInternalApiClient()).thenReturn(internalApiClient);
+        when(internalApiClient.privateChangedResourceHandler()).thenReturn(privateChangedResourceHandler);
+        when(privateChangedResourceHandler.postChangedResource(Mockito.any(), Mockito.any())).thenReturn(changedResourcePost);
+        when(changedResourcePost.execute()).thenThrow(RuntimeException.class);
+
+
+        Assert.assertThrows(RuntimeException.class, () -> disqualifiedOfficerApiService.invokeChsKafkaApi
+                ("3245435", "CH4000056", "natural"));
+
+        verify(apiClientService, times(1)).getInternalApiClient();
+        verify(internalApiClient, times(1)).privateChangedResourceHandler();
+        verify(privateChangedResourceHandler, times(1)).postChangedResource(Mockito.any(),
+                Mockito.any());
+        verify(changedResourcePost, times(1)).execute();
+    }
+
+    @ParameterizedTest
+    @MethodSource("provideExceptionParameters")
+    void should_handle_exception_when_chs_kafka_endpoint_throws_appropriate_exception(int statusCode, String statusMessage, Class<Throwable> exception) throws ApiErrorResponseException {
+        when(apiClientService.getInternalApiClient()).thenReturn(internalApiClient);
+        when(internalApiClient.privateChangedResourceHandler()).thenReturn(privateChangedResourceHandler);
+        when(privateChangedResourceHandler.postChangedResource(Mockito.any(), Mockito.any())).thenReturn(changedResourcePost);
+
+        HttpResponseException.Builder builder = new HttpResponseException.Builder(statusCode,
+                statusMessage, new HttpHeaders());
+        ApiErrorResponseException apiErrorResponseException =
+                new ApiErrorResponseException(builder);
+        when(changedResourcePost.execute()).thenThrow(apiErrorResponseException);
+
+        Assert.assertThrows(exception,
+                () -> disqualifiedOfficerApiService.invokeChsKafkaApi
+                        ("3245435", "CH4000056", "natural"));
+
+        verify(apiClientService, times(1)).getInternalApiClient();
+        verify(internalApiClient, times(1)).privateChangedResourceHandler();
+        verify(privateChangedResourceHandler, times(1)).postChangedResource(Mockito.any(),
+                Mockito.any());
+        verify(changedResourcePost, times(1)).execute();
+    }
+
+    private static Stream<Arguments> provideExceptionParameters() {
+        return Stream.of(
+                Arguments.of(503, "Service Unavailable", ServiceUnavailableException.class),
+                Arguments.of(405, "Method Not Allowed", MethodNotAllowedException.class),
+                Arguments.of(500, "Internal Service Error", RuntimeException.class)
+        );
+    }
+}

--- a/src/test/java/uk/gov/companieshouse/disqualifiedofficersdataapi/converter/DisqualifiedNaturalOfficerWriteConverterTest.java
+++ b/src/test/java/uk/gov/companieshouse/disqualifiedofficersdataapi/converter/DisqualifiedNaturalOfficerWriteConverterTest.java
@@ -5,7 +5,6 @@ import com.mongodb.BasicDBObject;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import uk.gov.companieshouse.api.disqualification.NaturalDisqualificationApi;
-import uk.gov.companieshouse.disqualifiedofficersdataapi.model.DisqualificationDocument;
 
 import static org.junit.Assert.assertTrue;
 

--- a/src/test/java/uk/gov/companieshouse/disqualifiedofficersdataapi/service/DisqualifiedOfficerServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/disqualifiedofficersdataapi/service/DisqualifiedOfficerServiceTest.java
@@ -11,6 +11,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.companieshouse.api.disqualification.InternalCorporateDisqualificationApi;
 import uk.gov.companieshouse.api.disqualification.InternalDisqualificationApiInternalData;
 import uk.gov.companieshouse.api.disqualification.InternalNaturalDisqualificationApi;
+import uk.gov.companieshouse.disqualifiedofficersdataapi.api.DisqualifiedOfficerApiService;
 import uk.gov.companieshouse.disqualifiedofficersdataapi.model.Created;
 import uk.gov.companieshouse.disqualifiedofficersdataapi.model.DisqualificationDocument;
 import uk.gov.companieshouse.disqualifiedofficersdataapi.model.Updated;
@@ -42,6 +43,9 @@ public class DisqualifiedOfficerServiceTest {
     @Mock
     private DisqualificationTransformer transformer;
 
+    @Mock
+    private DisqualifiedOfficerApiService disqualifiedOfficerApiService;
+
     @Captor
     private ArgumentCaptor<String> dateCaptor;
 
@@ -71,13 +75,14 @@ public class DisqualifiedOfficerServiceTest {
 
     @Test
     public void processNaturalDisqualificationSavesDisqualification() {
-        when(repository.findUpdatedDisqualification(eq(OFFICER_ID), dateCaptor.capture())).thenReturn(new ArrayList());
+        when(repository.findUpdatedDisqualification(eq(OFFICER_ID), dateCaptor.capture())).thenReturn(new ArrayList<>());
         when(repository.findById(OFFICER_ID)).thenReturn(Optional.empty());
         when(transformer.transformNaturalDisqualifiedOfficer(OFFICER_ID, request)).thenReturn(document);
 
         service.processNaturalDisqualification("", OFFICER_ID, request);
 
         verify(repository).save(document);
+        verify(disqualifiedOfficerApiService).invokeChsKafkaApi("", "officerId", "natural");
         assertEquals(dateString, dateCaptor.getValue());
         assertNotNull(document.getCreated().getAt());
     }
@@ -85,13 +90,14 @@ public class DisqualifiedOfficerServiceTest {
     @Test
     public void processNaturalDisqualificationUpdatesDisqualification() {
         document.setCreated(new Created().setAt(LocalDateTime.now()));
-        when(repository.findUpdatedDisqualification(eq(OFFICER_ID), dateCaptor.capture())).thenReturn(new ArrayList());
+        when(repository.findUpdatedDisqualification(eq(OFFICER_ID), dateCaptor.capture())).thenReturn(new ArrayList<>());
         when(repository.findById(OFFICER_ID)).thenReturn(Optional.of(document));
         when(transformer.transformNaturalDisqualifiedOfficer(OFFICER_ID, request)).thenReturn(document);
 
         service.processNaturalDisqualification("", OFFICER_ID, request);
 
         verify(repository).save(document);
+        verify(disqualifiedOfficerApiService).invokeChsKafkaApi("", "officerId", "natural");
         assertEquals(dateString, dateCaptor.getValue());
         assertNotNull(document.getCreated());
     }
@@ -106,18 +112,20 @@ public class DisqualifiedOfficerServiceTest {
         service.processNaturalDisqualification("", OFFICER_ID, request);
 
         verify(repository, times(0)).save(document);
+        verify(disqualifiedOfficerApiService, times(0)).invokeChsKafkaApi("", "officerId", "natural");
         assertEquals(dateString, dateCaptor.getValue());
     }
 
     @Test
     public void processCorporateDisqualificationSavesDisqualification() {
-        when(repository.findUpdatedDisqualification(eq(OFFICER_ID), dateCaptor.capture())).thenReturn(new ArrayList());
+        when(repository.findUpdatedDisqualification(eq(OFFICER_ID), dateCaptor.capture())).thenReturn(new ArrayList<>());
         when(repository.findById(OFFICER_ID)).thenReturn(Optional.empty());
         when(transformer.transformCorporateDisqualifiedOfficer(OFFICER_ID, corpRequest)).thenReturn(document);
 
         service.processCorporateDisqualification("", OFFICER_ID, corpRequest);
 
         verify(repository).save(document);
+        verify(disqualifiedOfficerApiService).invokeChsKafkaApi("", "officerId", "corporate");
         assertEquals(dateString, dateCaptor.getValue());
         assertNotNull(document.getCreated().getAt());
     }


### PR DESCRIPTION
This PR adds new functionality to call the Kafka apis resource-changed endpoint once an upsert has been saved to the mongo db.

**Resolves**
DSND-666