### PR TITLE
Add GET endpoint

### DIFF
--- a/routes.yaml
+++ b/routes.yaml
@@ -5,3 +5,5 @@ routes:
   1: ^/disqualified-officers/healthcheck
   2: ^/disqualified-officers/natural/(.*)/internal
   3: ^/disqualified-officers/corporate/(.*)/internal
+  4: ^/disqualified-officers/natural/(.*)
+  5: ^/disqualified-officers/corporate/(.*)

--- a/src/main/java/uk/gov/companieshouse/disqualifiedofficersdataapi/config/ApplicationConfig.java
+++ b/src/main/java/uk/gov/companieshouse/disqualifiedofficersdataapi/config/ApplicationConfig.java
@@ -8,8 +8,11 @@ import com.fasterxml.jackson.databind.module.SimpleModule;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.mongodb.core.convert.MongoCustomConversions;
+import uk.gov.companieshouse.disqualifiedofficersdataapi.converter.DisqualifiedCorporateOfficerReadConverter;
 import uk.gov.companieshouse.disqualifiedofficersdataapi.converter.DisqualifiedCorporateOfficerWriteConverter;
+import uk.gov.companieshouse.disqualifiedofficersdataapi.converter.DisqualifiedNaturalOfficerReadConverter;
 import uk.gov.companieshouse.disqualifiedofficersdataapi.converter.DisqualifiedNaturalOfficerWriteConverter;
+import uk.gov.companieshouse.disqualifiedofficersdataapi.serialization.LocalDateDeSerializer;
 import uk.gov.companieshouse.disqualifiedofficersdataapi.serialization.LocalDateSerializer;
 
 import java.time.LocalDate;
@@ -27,7 +30,9 @@ public class ApplicationConfig {
     public MongoCustomConversions mongoCustomConversions() {
         ObjectMapper objectMapper = mongoDbObjectMapper();
         return new MongoCustomConversions(List.of(new DisqualifiedNaturalOfficerWriteConverter(objectMapper),
-                new DisqualifiedCorporateOfficerWriteConverter(objectMapper)));
+                new DisqualifiedCorporateOfficerWriteConverter(objectMapper),
+                new DisqualifiedNaturalOfficerReadConverter(objectMapper),
+                new DisqualifiedCorporateOfficerReadConverter(objectMapper)));
     }
 
     /**
@@ -42,6 +47,7 @@ public class ApplicationConfig {
         objectMapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
         SimpleModule module = new SimpleModule();
         module.addSerializer(LocalDate.class, new LocalDateSerializer());
+        module.addDeserializer(LocalDate.class, new LocalDateDeSerializer());
         objectMapper.registerModule(module);
         return objectMapper;
     }

--- a/src/main/java/uk/gov/companieshouse/disqualifiedofficersdataapi/controller/DisqualifiedOfficerController.java
+++ b/src/main/java/uk/gov/companieshouse/disqualifiedofficersdataapi/controller/DisqualifiedOfficerController.java
@@ -10,6 +10,7 @@ import uk.gov.companieshouse.api.disqualification.CorporateDisqualificationApi;
 import uk.gov.companieshouse.api.disqualification.InternalCorporateDisqualificationApi;
 import uk.gov.companieshouse.api.disqualification.InternalNaturalDisqualificationApi;
 import uk.gov.companieshouse.api.disqualification.NaturalDisqualificationApi;
+import uk.gov.companieshouse.api.disqualification.PermissionToAct;
 import uk.gov.companieshouse.disqualifiedofficersdataapi.model.*;
 import uk.gov.companieshouse.disqualifiedofficersdataapi.service.DisqualifiedOfficerService;
 
@@ -84,6 +85,11 @@ public class DisqualifiedOfficerController {
                 officerId));
 
         NaturalDisqualificationDocument disqualification = service.retrieveNaturalDisqualification(officerId);
+        NaturalDisqualificationApi data = disqualification.getData();
+        for (PermissionToAct permissionToAct:data.getPermissionsToAct()) {
+            permissionToAct.setPurpose(null);
+        }
+        data.setPersonNumber(null);
 
         return ResponseEntity.status(HttpStatus.OK).body(disqualification.getData());
     }
@@ -103,6 +109,11 @@ public class DisqualifiedOfficerController {
 
         CorporateDisqualificationDocument disqualification = service.retrieveCorporateDisqualification(
                 officerId);
+        CorporateDisqualificationApi data = disqualification.getData();
+        for (PermissionToAct permissionToAct:data.getPermissionsToAct()) {
+            permissionToAct.setPurpose(null);
+        }
+        data.setPersonNumber(null);
 
         return ResponseEntity.status(HttpStatus.OK).body(disqualification.getData());
     }

--- a/src/main/java/uk/gov/companieshouse/disqualifiedofficersdataapi/controller/DisqualifiedOfficerController.java
+++ b/src/main/java/uk/gov/companieshouse/disqualifiedofficersdataapi/controller/DisqualifiedOfficerController.java
@@ -4,14 +4,13 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PutMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestHeader;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
+import uk.gov.companieshouse.api.disqualification.CorporateDisqualificationApi;
 import uk.gov.companieshouse.api.disqualification.InternalCorporateDisqualificationApi;
 import uk.gov.companieshouse.api.disqualification.InternalNaturalDisqualificationApi;
+import uk.gov.companieshouse.api.disqualification.NaturalDisqualificationApi;
+import uk.gov.companieshouse.disqualifiedofficersdataapi.model.*;
 import uk.gov.companieshouse.disqualifiedofficersdataapi.service.DisqualifiedOfficerService;
 
 import uk.gov.companieshouse.logging.Logger;
@@ -69,5 +68,42 @@ public class DisqualifiedOfficerController {
         service.processCorporateDisqualification(contextId, officerId, requestBody);
 
         return ResponseEntity.status(HttpStatus.OK).build();
+    }
+
+    /**
+     * Retrieve natural disqualified officer information for a officer ID.
+     *
+     * @param  officerId  the officer ID for the disqualification
+     * @return NaturalDisqualificationDocument return natural disqualified officer information
+     */
+    @GetMapping("/disqualified-officers/natural/{officer_id}")
+    public ResponseEntity<NaturalDisqualificationApi> naturalDisqualification(
+            @PathVariable("officer_id") final String officerId) {
+        logger.info(String.format(
+                "Retrieving natural officer disqualification information for officer ID %s",
+                officerId));
+
+        NaturalDisqualificationDocument disqualification = service.retrieveNaturalDisqualification(officerId);
+
+        return ResponseEntity.status(HttpStatus.OK).body(disqualification.getData());
+    }
+
+    /**
+     * Retrieve corporate disqualified officer information for a officer ID.
+     *
+     * @param  officerId  the officer ID for the disqualification
+     * @return CorporateDisqualificationDocument return corporate disqualified officer information
+     */
+    @GetMapping("/disqualified-officers/corporate/{officer_id}")
+    public ResponseEntity<CorporateDisqualificationApi> corporateDisqualification(
+            @PathVariable("officer_id") String officerId) {
+        logger.info(String.format(
+                "Retrieving corporate officer disqualification information for officer ID %s",
+                officerId));
+
+        CorporateDisqualificationDocument disqualification = service.retrieveCorporateDisqualification(
+                officerId);
+
+        return ResponseEntity.status(HttpStatus.OK).body(disqualification.getData());
     }
 }

--- a/src/main/java/uk/gov/companieshouse/disqualifiedofficersdataapi/converter/DisqualifiedCorporateOfficerReadConverter.java
+++ b/src/main/java/uk/gov/companieshouse/disqualifiedofficersdataapi/converter/DisqualifiedCorporateOfficerReadConverter.java
@@ -1,0 +1,31 @@
+package uk.gov.companieshouse.disqualifiedofficersdataapi.converter;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.bson.Document;
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.data.convert.ReadingConverter;
+import uk.gov.companieshouse.api.disqualification.CorporateDisqualificationApi;
+
+@ReadingConverter
+public class DisqualifiedCorporateOfficerReadConverter implements Converter<Document, CorporateDisqualificationApi> {
+
+    private final ObjectMapper objectMapper;
+
+    public DisqualifiedCorporateOfficerReadConverter(ObjectMapper objectMapper) {
+        this.objectMapper = objectMapper;
+    }
+
+    /**
+     * Write convertor.
+     * @param source source Document.
+     * @return charge BSON object.
+     */
+    @Override
+    public CorporateDisqualificationApi convert(Document source) {
+        try {
+            return objectMapper.readValue(source.toJson(), CorporateDisqualificationApi.class);
+        } catch (Exception ex) {
+            throw new RuntimeException(ex);
+        }
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/disqualifiedofficersdataapi/converter/DisqualifiedNaturalOfficerReadConverter.java
+++ b/src/main/java/uk/gov/companieshouse/disqualifiedofficersdataapi/converter/DisqualifiedNaturalOfficerReadConverter.java
@@ -1,0 +1,31 @@
+package uk.gov.companieshouse.disqualifiedofficersdataapi.converter;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.bson.Document;
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.data.convert.ReadingConverter;
+import uk.gov.companieshouse.api.disqualification.NaturalDisqualificationApi;
+
+@ReadingConverter
+public class DisqualifiedNaturalOfficerReadConverter implements Converter<Document, NaturalDisqualificationApi> {
+
+    private final ObjectMapper objectMapper;
+
+    public DisqualifiedNaturalOfficerReadConverter(ObjectMapper objectMapper) {
+        this.objectMapper = objectMapper;
+    }
+
+    /**
+     * Write convertor.
+     * @param source source Document.
+     * @return charge BSON object.
+     */
+    @Override
+    public NaturalDisqualificationApi convert(Document source) {
+        try {
+            return objectMapper.readValue(source.toJson(), NaturalDisqualificationApi.class);
+        } catch (Exception ex) {
+            throw new RuntimeException(ex);
+        }
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/disqualifiedofficersdataapi/repository/CorporateDisqualifiedOfficerRepository.java
+++ b/src/main/java/uk/gov/companieshouse/disqualifiedofficersdataapi/repository/CorporateDisqualifiedOfficerRepository.java
@@ -1,0 +1,11 @@
+package uk.gov.companieshouse.disqualifiedofficersdataapi.repository;
+
+import org.springframework.data.mongodb.repository.MongoRepository;
+import org.springframework.stereotype.Repository;
+import uk.gov.companieshouse.disqualifiedofficersdataapi.model.CorporateDisqualificationDocument;
+
+
+@Repository
+public interface CorporateDisqualifiedOfficerRepository extends MongoRepository<CorporateDisqualificationDocument, String> {
+
+}

--- a/src/main/java/uk/gov/companieshouse/disqualifiedofficersdataapi/repository/NaturalDisqualifiedOfficerRepository.java
+++ b/src/main/java/uk/gov/companieshouse/disqualifiedofficersdataapi/repository/NaturalDisqualifiedOfficerRepository.java
@@ -1,0 +1,11 @@
+package uk.gov.companieshouse.disqualifiedofficersdataapi.repository;
+
+import org.springframework.data.mongodb.repository.MongoRepository;
+import org.springframework.stereotype.Repository;
+
+import uk.gov.companieshouse.disqualifiedofficersdataapi.model.NaturalDisqualificationDocument;
+
+@Repository
+public interface NaturalDisqualifiedOfficerRepository extends MongoRepository<NaturalDisqualificationDocument, String> {
+
+}

--- a/src/main/java/uk/gov/companieshouse/disqualifiedofficersdataapi/serialization/LocalDateDeSerializer.java
+++ b/src/main/java/uk/gov/companieshouse/disqualifiedofficersdataapi/serialization/LocalDateDeSerializer.java
@@ -1,0 +1,32 @@
+package uk.gov.companieshouse.disqualifiedofficersdataapi.serialization;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.JsonNode;
+import uk.gov.companieshouse.disqualifiedofficersdataapi.exceptions.BadRequestException;
+import uk.gov.companieshouse.logging.Logger;
+import uk.gov.companieshouse.logging.LoggerFactory;
+
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+
+public class LocalDateDeSerializer extends JsonDeserializer<LocalDate> {
+    public static final String APPLICATION_NAME_SPACE = "disqualified-officers-data-api";
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(APPLICATION_NAME_SPACE);
+
+    @Override
+    public LocalDate deserialize(JsonParser jsonParser, DeserializationContext
+            deserializationContext) {
+        try {
+            DateTimeFormatter dateTimeFormatter = DateTimeFormatter
+                    .ofPattern("yyyy-MM-dd'T'HH:mm:ss'Z'");
+            JsonNode jsonNode = jsonParser.readValueAsTree();
+            return LocalDate.parse(jsonNode.get("$date").textValue(), dateTimeFormatter);
+        } catch (Exception exception) {
+            LOGGER.error("Deserialization failed.", exception);
+            throw new BadRequestException(exception.getMessage());
+        }
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/disqualifiedofficersdataapi/service/DisqualifiedOfficerService.java
+++ b/src/main/java/uk/gov/companieshouse/disqualifiedofficersdataapi/service/DisqualifiedOfficerService.java
@@ -4,9 +4,10 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import uk.gov.companieshouse.api.disqualification.InternalCorporateDisqualificationApi;
 import uk.gov.companieshouse.api.disqualification.InternalNaturalDisqualificationApi;
-import uk.gov.companieshouse.disqualifiedofficersdataapi.model.Created;
-import uk.gov.companieshouse.disqualifiedofficersdataapi.model.DisqualificationDocument;
+import uk.gov.companieshouse.disqualifiedofficersdataapi.model.*;
+import uk.gov.companieshouse.disqualifiedofficersdataapi.repository.CorporateDisqualifiedOfficerRepository;
 import uk.gov.companieshouse.disqualifiedofficersdataapi.repository.DisqualifiedOfficerRepository;
+import uk.gov.companieshouse.disqualifiedofficersdataapi.repository.NaturalDisqualifiedOfficerRepository;
 import uk.gov.companieshouse.disqualifiedofficersdataapi.transform.DisqualificationTransformer;
 
 import java.time.OffsetDateTime;
@@ -19,6 +20,13 @@ public class DisqualifiedOfficerService {
 
     @Autowired
     private DisqualifiedOfficerRepository repository;
+
+    @Autowired
+    private NaturalDisqualifiedOfficerRepository naturalRepository;
+
+    @Autowired
+    private CorporateDisqualifiedOfficerRepository corporateRepository;
+
     @Autowired
     private DisqualificationTransformer transformer;
 
@@ -103,6 +111,32 @@ public class DisqualifiedOfficerService {
         Optional<DisqualificationDocument> doc = repository.findById(officerId);
 
         return doc.isPresent() ? doc.get().getCreated(): null;
+    }
+
+    public NaturalDisqualificationDocument retrieveNaturalDisqualification(String officerId) {
+        Optional<NaturalDisqualificationDocument> disqualificationDocumentOptional =
+                naturalRepository.findById(officerId);
+        NaturalDisqualificationDocument disqualificationDocument = disqualificationDocumentOptional.orElseThrow(
+                () -> new IllegalArgumentException(String.format(
+                        "Resource not found for officer ID: %s", officerId)));
+        if(disqualificationDocument.isCorporateOfficer()) {
+            throw new IllegalArgumentException(String.format(
+                    "Natural resource not found for officer ID: %s", officerId));
+        }
+        return disqualificationDocument;
+    }
+
+    public CorporateDisqualificationDocument retrieveCorporateDisqualification(String officerId) {
+        Optional<CorporateDisqualificationDocument> disqualificationDocumentOptional =
+                corporateRepository.findById(officerId);
+        CorporateDisqualificationDocument disqualificationDocument = disqualificationDocumentOptional.orElseThrow(
+                () -> new IllegalArgumentException(String.format(
+                        "Resource not found for officer ID: %s", officerId)));
+        if(!disqualificationDocument.isCorporateOfficer()) {
+            throw new IllegalArgumentException(String.format(
+                    "Corporate resource not found for officer ID: %s", officerId));
+        }
+        return disqualificationDocument;
     }
 
 }

--- a/src/test/java/uk/gov/companieshouse/disqualifiedofficersdataapi/converter/DisqualifiedCorporateOfficerReadConverterTest.java
+++ b/src/test/java/uk/gov/companieshouse/disqualifiedofficersdataapi/converter/DisqualifiedCorporateOfficerReadConverterTest.java
@@ -1,0 +1,30 @@
+package uk.gov.companieshouse.disqualifiedofficersdataapi.converter;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.bson.Document;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import uk.gov.companieshouse.api.disqualification.CorporateDisqualificationApi;
+import uk.gov.companieshouse.api.disqualification.NaturalDisqualificationApi;
+
+import static org.junit.Assert.assertEquals;
+
+public class DisqualifiedCorporateOfficerReadConverterTest {
+
+    private static final String COMPANY_NUMBER = "123456";
+
+    private DisqualifiedCorporateOfficerReadConverter converter;
+
+    @BeforeEach
+    public void setUp() {
+        converter = new DisqualifiedCorporateOfficerReadConverter(new ObjectMapper());
+    }
+
+    @Test
+    public void canConvertDocument() {
+        Document document = new Document("company_number", COMPANY_NUMBER);
+        CorporateDisqualificationApi disqualification = converter.convert(document);
+
+        assertEquals(disqualification.getCompanyNumber(),COMPANY_NUMBER);
+    }
+}

--- a/src/test/java/uk/gov/companieshouse/disqualifiedofficersdataapi/converter/DisqualifiedNaturalOfficerReadConverterTest.java
+++ b/src/test/java/uk/gov/companieshouse/disqualifiedofficersdataapi/converter/DisqualifiedNaturalOfficerReadConverterTest.java
@@ -1,0 +1,30 @@
+package uk.gov.companieshouse.disqualifiedofficersdataapi.converter;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.mongodb.BasicDBObject;
+import org.bson.Document;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import uk.gov.companieshouse.api.disqualification.NaturalDisqualificationApi;
+
+import static org.junit.Assert.assertEquals;
+
+public class DisqualifiedNaturalOfficerReadConverterTest {
+
+    private static final String OFFICER_NAME = "officer";
+
+    private DisqualifiedNaturalOfficerReadConverter converter;
+
+    @BeforeEach
+    public void setUp() {
+        converter = new DisqualifiedNaturalOfficerReadConverter(new ObjectMapper());
+    }
+
+    @Test
+    public void canConvertDocument() {
+        Document document = new Document("forename", OFFICER_NAME);
+        NaturalDisqualificationApi disqualification = converter.convert(document);
+
+        assertEquals(disqualification.getForename(),OFFICER_NAME);
+    }
+}


### PR DESCRIPTION
This PR adds GET endpoint handlers for natural and corporate officer paths, these in turn call a method in the service that retrieves a NaturalDisqualificationDocument or CorporateDisqualificationDocument using the appropriate repository.
The data inside the Document is then retrieved, person number and purpose are nulled and the data is sent back in the response.
ReadConverters for natural and corporate are also added as well as their own repository interfaces.

**Resolves:**
- DSND-701