### PR TITLE
Correct mongo field names

### DIFF
--- a/src/main/java/uk/gov/companieshouse/disqualifiedofficersdataapi/model/DisqualificationDocument.java
+++ b/src/main/java/uk/gov/companieshouse/disqualifiedofficersdataapi/model/DisqualificationDocument.java
@@ -22,8 +22,10 @@ public class DisqualificationDocument {
 
     private Created created;
 
+    @Field("delta_at")
     private String deltaAt;
 
+    @Field("is_corporate_officer")
     private boolean isCorporateOfficer;
 
     private Updated updated;


### PR DESCRIPTION
This pr corrects two mongo field names for disqualifications to fix the display fo corporate disqualified officers on CHS.

**Resolves:**
- DSND-887