### PR TITLE
Add new exceptions to config

### DIFF
--- a/src/main/java/uk/gov/companieshouse/disqualifiedofficersdataapi/config/ExceptionHandlerConfig.java
+++ b/src/main/java/uk/gov/companieshouse/disqualifiedofficersdataapi/config/ExceptionHandlerConfig.java
@@ -8,6 +8,7 @@ import java.util.Map;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.context.request.WebRequest;
@@ -42,7 +43,26 @@ public class ExceptionHandlerConfig {
         responseBody.put("timestamp", LocalDateTime.now());
         responseBody.put("message", "Unable to process the request.");
         request.setAttribute("javax.servlet.error.exception", ex, 0);
-        return new ResponseEntity(responseBody, HttpStatus.INTERNAL_SERVER_ERROR);
+        return new ResponseEntity<>(responseBody, HttpStatus.INTERNAL_SERVER_ERROR);
+    }
+
+    /**
+     * IllegalArgumentException exception handler.
+     *
+     * @param ex      exception to handle.
+     * @param request request.
+     * @return error response to return.
+     */
+    @ExceptionHandler(value = {IllegalArgumentException.class})
+    public ResponseEntity<Object> handleNotFoundException(Exception ex, WebRequest request) {
+        logger.error(String.format("Resource not found, response code: %s",
+                HttpStatus.NOT_FOUND), ex);
+
+        Map<String, Object> responseBody = new LinkedHashMap<>();
+        responseBody.put("timestamp", LocalDateTime.now());
+        responseBody.put("message", "Resource not found.");
+        request.setAttribute("javax.servlet.error.exception", ex, 0);
+        return new ResponseEntity<>(responseBody, HttpStatus.NOT_FOUND);
     }
 
     /**
@@ -62,7 +82,7 @@ public class ExceptionHandlerConfig {
         responseBody.put("timestamp", LocalDateTime.now());
         responseBody.put("message", "Unable to process the request.");
         request.setAttribute("javax.servlet.error.exception", ex, 0);
-        return new ResponseEntity(responseBody, HttpStatus.METHOD_NOT_ALLOWED);
+        return new ResponseEntity<>(responseBody, HttpStatus.METHOD_NOT_ALLOWED);
     }
 
     /**
@@ -83,7 +103,7 @@ public class ExceptionHandlerConfig {
         responseBody.put("timestamp", LocalDateTime.now());
         responseBody.put("message", "Service unavailable.");
         request.setAttribute("javax.servlet.error.exception", ex, 0);
-        return new ResponseEntity(responseBody, HttpStatus.SERVICE_UNAVAILABLE);
+        return new ResponseEntity<>(responseBody, HttpStatus.SERVICE_UNAVAILABLE);
     }
 
     /**
@@ -94,7 +114,8 @@ public class ExceptionHandlerConfig {
      * @param request request.
      * @return error response to return.
      */
-    @ExceptionHandler(value = {BadRequestException.class, DateTimeParseException.class})
+    @ExceptionHandler(value = {BadRequestException.class, DateTimeParseException.class,
+        HttpMessageNotReadableException.class})
     public ResponseEntity<Object> handleBadRequestException(Exception ex, WebRequest request) {
         logger.error(String.format("Bad request, response code: %s", HttpStatus.BAD_REQUEST), ex);
 
@@ -102,6 +123,6 @@ public class ExceptionHandlerConfig {
         responseBody.put("timestamp", LocalDateTime.now());
         responseBody.put("message", "Bad request.");
         request.setAttribute("javax.servlet.error.exception", ex, 0);
-        return new ResponseEntity(responseBody, HttpStatus.BAD_REQUEST);
+        return new ResponseEntity<>(responseBody, HttpStatus.BAD_REQUEST);
     }
 }

--- a/src/main/java/uk/gov/companieshouse/disqualifiedofficersdataapi/repository/DisqualifiedOfficerRepository.java
+++ b/src/main/java/uk/gov/companieshouse/disqualifiedofficersdataapi/repository/DisqualifiedOfficerRepository.java
@@ -11,5 +11,5 @@ import java.util.List;
 public interface DisqualifiedOfficerRepository extends MongoRepository<DisqualificationDocument, String> {
 
     @Query("{'_id': ?0, 'updated.at':{$gte : { \"$date\" : \"?1\" } }}")
-    List findUpdatedDisqualification(String officerId, String at);
+    List<DisqualificationDocument> findUpdatedDisqualification(String officerId, String at);
 }

--- a/src/main/java/uk/gov/companieshouse/disqualifiedofficersdataapi/service/DisqualifiedOfficerService.java
+++ b/src/main/java/uk/gov/companieshouse/disqualifiedofficersdataapi/service/DisqualifiedOfficerService.java
@@ -87,7 +87,8 @@ public class DisqualifiedOfficerService {
      */
     private boolean isLatestRecord(String officerId, OffsetDateTime deltaAt) {
         String formattedDate = deltaAt.format(dateTimeFormatter);
-        List disqualifications = repository.findUpdatedDisqualification(officerId, formattedDate);
+        List<DisqualificationDocument> disqualifications = repository
+                .findUpdatedDisqualification(officerId, formattedDate);
         return disqualifications.isEmpty();
     }
 

--- a/src/main/java/uk/gov/companieshouse/disqualifiedofficersdataapi/transform/DisqualificationTransformer.java
+++ b/src/main/java/uk/gov/companieshouse/disqualifiedofficersdataapi/transform/DisqualificationTransformer.java
@@ -2,7 +2,6 @@ package uk.gov.companieshouse.disqualifiedofficersdataapi.transform;
 
 import org.springframework.stereotype.Component;
 import uk.gov.companieshouse.GenerateEtagUtil;
-import uk.gov.companieshouse.api.disqualification.CorporateDisqualificationApi;
 import uk.gov.companieshouse.api.disqualification.InternalCorporateDisqualificationApi;
 import uk.gov.companieshouse.api.disqualification.InternalDisqualificationApiInternalData;
 import uk.gov.companieshouse.api.disqualification.InternalNaturalDisqualificationApi;

--- a/src/test/java/uk/gov/companieshouse/disqualifiedofficersdataapi/api/controller/DisqualifiedOfficerControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/disqualifiedofficersdataapi/api/controller/DisqualifiedOfficerControllerTest.java
@@ -1,0 +1,171 @@
+package uk.gov.companieshouse.disqualifiedofficersdataapi.api.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.github.dockerjava.api.exception.InternalServerErrorException;
+import com.google.gson.Gson;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.test.web.servlet.MockMvc;
+
+import uk.gov.companieshouse.api.disqualification.InternalDisqualificationApiInternalData;
+import uk.gov.companieshouse.api.disqualification.InternalNaturalDisqualificationApi;
+import uk.gov.companieshouse.api.disqualification.NaturalDisqualificationApi;
+import uk.gov.companieshouse.disqualifiedofficersdataapi.config.ExceptionHandlerConfig;
+import uk.gov.companieshouse.disqualifiedofficersdataapi.controller.DisqualifiedOfficerController;
+import uk.gov.companieshouse.disqualifiedofficersdataapi.exceptions.BadRequestException;
+import uk.gov.companieshouse.disqualifiedofficersdataapi.exceptions.MethodNotAllowedException;
+import uk.gov.companieshouse.disqualifiedofficersdataapi.exceptions.ServiceUnavailableException;
+import uk.gov.companieshouse.disqualifiedofficersdataapi.service.DisqualifiedOfficerService;
+import uk.gov.companieshouse.logging.Logger;
+
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.isA;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doThrow;
+import static org.springframework.http.MediaType.APPLICATION_JSON;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@ExtendWith(SpringExtension.class)
+@WebMvcTest(controllers = DisqualifiedOfficerController.class)
+@ContextConfiguration(classes = {DisqualifiedOfficerController.class, ExceptionHandlerConfig.class})
+class DisqualifiedOfficerControllerTest {
+    private static final String OFFICER_ID = "02588581";
+    private static final String NATURAL = "natural";
+    private static final String NATURAL_URL = String.format("/disqualified-officers/%s/%s/internal", NATURAL, OFFICER_ID);
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private Logger logger;
+
+    @MockBean
+    private DisqualifiedOfficerService disqualifiedOfficerService;
+
+    private ObjectMapper mapper = new ObjectMapper();
+
+    private Gson gson = new Gson();
+
+    @BeforeEach
+    void setUp() {
+        mapper.registerModule(new JavaTimeModule());
+        mapper.configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false);
+    }
+
+    @Test
+    @DisplayName("Disqualified Officer PUT request")
+    public void callDisqualifiedOfficerPutRequest() throws Exception {
+        InternalNaturalDisqualificationApi request = new InternalNaturalDisqualificationApi();
+        request.setInternalData(new InternalDisqualificationApiInternalData());
+        request.setExternalData(new NaturalDisqualificationApi());
+
+        doNothing().when(disqualifiedOfficerService).processNaturalDisqualification(anyString(), anyString(),
+                isA(InternalNaturalDisqualificationApi.class));
+
+        mockMvc.perform(put(NATURAL_URL)
+                        .contentType(APPLICATION_JSON)
+                        .header("x-request-id", "5342342")
+                        .content(gson.toJson(request)))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    @DisplayName("Disqualified Officer PUT request - IllegalArgumentException status code 404 not found")
+    public void callDisqualifiedOfficerPutRequestIllegalArgument() throws Exception {
+        InternalNaturalDisqualificationApi request = new InternalNaturalDisqualificationApi();
+        request.setInternalData(new InternalDisqualificationApiInternalData());
+        request.setExternalData(new NaturalDisqualificationApi());
+
+        doThrow(new IllegalArgumentException())
+                .when(disqualifiedOfficerService).processNaturalDisqualification(anyString(), anyString(),
+                        isA(InternalNaturalDisqualificationApi.class));
+
+        mockMvc.perform(put(NATURAL_URL)
+                        .contentType(APPLICATION_JSON)
+                        .header("x-request-id", "5342342")
+                        .content(gson.toJson(request)))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    @DisplayName("Disqualified Officer PUT request - BadRequestException status code 400")
+    public void callDisqualifiedOfficerPutRequestBadRequest() throws Exception {
+        InternalNaturalDisqualificationApi request = new InternalNaturalDisqualificationApi();
+        request.setInternalData(new InternalDisqualificationApiInternalData());
+        request.setExternalData(new NaturalDisqualificationApi());
+
+        doThrow(new BadRequestException("Bad request - data in wrong format"))
+                        .when(disqualifiedOfficerService).processNaturalDisqualification(anyString(), anyString(),
+                                        isA(InternalNaturalDisqualificationApi.class));
+
+        mockMvc.perform(put(NATURAL_URL)
+                        .contentType(APPLICATION_JSON)
+                        .header("x-request-id", "5342342")
+                        .content(gson.toJson(request)))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("Disqualified Officer PUT request - MethodNotAllowed status code 405")
+    public void callDisqualifiedOfficerPutRequestMethodNotAllowed() throws Exception {
+        InternalNaturalDisqualificationApi request = new InternalNaturalDisqualificationApi();
+        request.setInternalData(new InternalDisqualificationApiInternalData());
+        request.setExternalData(new NaturalDisqualificationApi());
+
+        doThrow(new MethodNotAllowedException(String.format("Method Not Allowed - unsuccessful call to %s endpoint", NATURAL_URL)))
+                .when(disqualifiedOfficerService).processNaturalDisqualification(anyString(), anyString(),
+                        isA(InternalNaturalDisqualificationApi.class));
+
+        mockMvc.perform(put(NATURAL_URL)
+                        .contentType(APPLICATION_JSON)
+                        .header("x-request-id", "5342342")
+                        .content(gson.toJson(request)))
+                .andExpect(status().isMethodNotAllowed());
+    }
+
+    @Test
+    @DisplayName("Disqualified Officer PUT request - InternalServerError status code 500")
+    public void callDisqualifiedOfficerPutRequestInternalServerError() throws Exception {
+        InternalNaturalDisqualificationApi request = new InternalNaturalDisqualificationApi();
+        request.setInternalData(new InternalDisqualificationApiInternalData());
+        request.setExternalData(new NaturalDisqualificationApi());
+
+        doThrow(new InternalServerErrorException("Internal Server Error - unexpected error"))
+                .when(disqualifiedOfficerService).processNaturalDisqualification(anyString(), anyString(),
+                        isA(InternalNaturalDisqualificationApi.class));
+
+        mockMvc.perform(put(NATURAL_URL)
+                        .contentType(APPLICATION_JSON)
+                        .header("x-request-id", "5342342")
+                        .content(gson.toJson(request)))
+                .andExpect(status().isInternalServerError());
+    }
+
+    @Test
+    @DisplayName("Disqualified Officer PUT request - ServiceUnavailable status code 503")
+    public void callDisqualifiedOfficerPutRequestServiceUnavailable() throws Exception {
+        InternalNaturalDisqualificationApi request = new InternalNaturalDisqualificationApi();
+        request.setInternalData(new InternalDisqualificationApiInternalData());
+        request.setExternalData(new NaturalDisqualificationApi());
+
+        doThrow(new ServiceUnavailableException("Service Unavailable - connection issues"))
+                .when(disqualifiedOfficerService).processNaturalDisqualification(anyString(), anyString(),
+                        isA(InternalNaturalDisqualificationApi.class));
+
+        mockMvc.perform(put(NATURAL_URL)
+                        .contentType(APPLICATION_JSON)
+                        .header("x-request-id", "5342342")
+                        .content(gson.toJson(request)))
+                .andExpect(status().isServiceUnavailable());
+    }
+}

--- a/src/test/java/uk/gov/companieshouse/disqualifiedofficersdataapi/converter/DisqualifiedCorporateOfficerReadConverterTest.java
+++ b/src/test/java/uk/gov/companieshouse/disqualifiedofficersdataapi/converter/DisqualifiedCorporateOfficerReadConverterTest.java
@@ -5,7 +5,6 @@ import org.bson.Document;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import uk.gov.companieshouse.api.disqualification.CorporateDisqualificationApi;
-import uk.gov.companieshouse.api.disqualification.NaturalDisqualificationApi;
 
 import static org.junit.Assert.assertEquals;
 

--- a/src/test/java/uk/gov/companieshouse/disqualifiedofficersdataapi/converter/DisqualifiedNaturalOfficerReadConverterTest.java
+++ b/src/test/java/uk/gov/companieshouse/disqualifiedofficersdataapi/converter/DisqualifiedNaturalOfficerReadConverterTest.java
@@ -1,7 +1,6 @@
 package uk.gov.companieshouse.disqualifiedofficersdataapi.converter;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.mongodb.BasicDBObject;
 import org.bson.Document;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;


### PR DESCRIPTION
This PR adds a new exception type for IllegalArgumentException and HttpMessageNotReadableException so that the proper response is sent after a put/get request.

**resolves**
DSND-661