### PR TITLE
Add integration disqualification response codes

### DIFF
--- a/src/itest/java/uk/gov/companieshouse/disqualifiedofficersdataapi/repository/RepositoryITest.java
+++ b/src/itest/java/uk/gov/companieshouse/disqualifiedofficersdataapi/repository/RepositoryITest.java
@@ -1,6 +1,5 @@
 package uk.gov.companieshouse.disqualifiedofficersdataapi.repository;
 
-import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.AfterAll;
@@ -10,20 +9,13 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.mongo.embedded.EmbeddedMongoAutoConfiguration;
 import org.springframework.boot.test.autoconfigure.data.mongo.DataMongoTest;
 import org.testcontainers.junit.jupiter.Testcontainers;
-import uk.gov.companieshouse.GenerateEtagUtil;
 import uk.gov.companieshouse.api.disqualification.NaturalDisqualificationApi;
 import uk.gov.companieshouse.disqualifiedofficersdataapi.config.AbstractMongoConfig;
-import uk.gov.companieshouse.disqualifiedofficersdataapi.model.DisqualificationDocument;
 import uk.gov.companieshouse.disqualifiedofficersdataapi.model.NaturalDisqualificationDocument;
-import uk.gov.companieshouse.disqualifiedofficersdataapi.repository.DisqualifiedOfficerRepository;
-import uk.gov.companieshouse.disqualifiedofficersdataapi.repository.NaturalDisqualifiedOfficerRepository;
 
 @Testcontainers
 @DataMongoTest(excludeAutoConfiguration = EmbeddedMongoAutoConfiguration.class)
 public class RepositoryITest extends AbstractMongoConfig {
-
-  @Autowired
-  private DisqualifiedOfficerRepository repository;
 
   @Autowired
   private NaturalDisqualifiedOfficerRepository naturalRepository;

--- a/src/itest/java/uk/gov/companieshouse/disqualifiedofficersdataapi/steps/CorporateDisqualificationSteps.java
+++ b/src/itest/java/uk/gov/companieshouse/disqualifiedofficersdataapi/steps/CorporateDisqualificationSteps.java
@@ -109,7 +109,6 @@ public class CorporateDisqualificationSteps {
         CucumberContext.CONTEXT.set("statusCode", response.getStatusCodeValue());
     }
 
-
     @Then("the corporate Get call response body should match {string} file")
     public void the_corporate_get_call_response_body_should_match(String dataFile) throws IOException {
        File file = new ClassPathResource("/json/output/" + dataFile + ".json").getFile();

--- a/src/itest/java/uk/gov/companieshouse/disqualifiedofficersdataapi/steps/DisqualificationSteps.java
+++ b/src/itest/java/uk/gov/companieshouse/disqualifiedofficersdataapi/steps/DisqualificationSteps.java
@@ -4,7 +4,9 @@ import java.io.IOException;
 import java.util.List;
 
 import com.github.dockerjava.api.exception.InternalServerErrorException;
-import io.cucumber.java.en.*;
+import io.cucumber.java.en.Given;
+import io.cucumber.java.en.Then;
+import io.cucumber.java.en.When;
 import org.assertj.core.api.Assertions;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.web.client.TestRestTemplate;
@@ -16,6 +18,8 @@ import uk.gov.companieshouse.disqualifiedofficersdataapi.model.DisqualificationD
 import uk.gov.companieshouse.disqualifiedofficersdataapi.repository.DisqualifiedOfficerRepository;
 
 import static org.assertj.core.api.Assertions.assertThat;
+
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 import static uk.gov.companieshouse.disqualifiedofficersdataapi.config.AbstractMongoConfig.mongoDBContainer;
 

--- a/src/itest/java/uk/gov/companieshouse/disqualifiedofficersdataapi/steps/DisqualificationSteps.java
+++ b/src/itest/java/uk/gov/companieshouse/disqualifiedofficersdataapi/steps/DisqualificationSteps.java
@@ -1,16 +1,23 @@
 package uk.gov.companieshouse.disqualifiedofficersdataapi.steps;
 
-import io.cucumber.java.en.Given;
-import io.cucumber.java.en.Then;
+import java.io.IOException;
+import java.util.List;
+
+import io.cucumber.java.en.*;
 import org.assertj.core.api.Assertions;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.web.client.TestRestTemplate;
 import uk.gov.companieshouse.disqualifiedofficersdataapi.api.DisqualifiedOfficerApiService;
 import uk.gov.companieshouse.disqualifiedofficersdataapi.api.ResourceChangedRequest;
 import uk.gov.companieshouse.disqualifiedofficersdataapi.config.CucumberContext;
+import uk.gov.companieshouse.disqualifiedofficersdataapi.exceptions.InternalServerErrorException;
+import uk.gov.companieshouse.disqualifiedofficersdataapi.exceptions.ServiceUnavailableException;
+import uk.gov.companieshouse.disqualifiedofficersdataapi.model.DisqualificationDocument;
+import uk.gov.companieshouse.disqualifiedofficersdataapi.repository.DisqualifiedOfficerRepository;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.*;
+import static uk.gov.companieshouse.disqualifiedofficersdataapi.config.AbstractMongoConfig.mongoDBContainer;
 
 public class DisqualificationSteps {
 
@@ -20,18 +27,49 @@ public class DisqualificationSteps {
     @Autowired
     protected TestRestTemplate restTemplate;
 
+    @Autowired
+    private DisqualifiedOfficerRepository repository;
+
     @Given("disqualified officers data api service is running")
     public void theApplicationRunning() {
         assertThat(restTemplate).isNotNull();
     }
 
+    @Given("the disqualification database is down")
+    public void the_disqualification_db_is_down() {
+        mongoDBContainer.stop();
+    }
+
+    @When("CHS kafka API service is unavailable")
+    public void chs_kafka_service_unavailable() throws IOException {
+        doThrow(ServiceUnavailableException.class)
+            .when(disqualifiedApiService).invokeChsKafkaApi(any(ResourceChangedRequest.class));
+    }
+
+    @When("the api throws an internal server error")
+    public void api_throws_an_internal_service_error() throws IOException {
+        doThrow(InternalServerErrorException.class)
+            .when(disqualifiedApiService).invokeChsKafkaApi(any(ResourceChangedRequest.class));
+    }
+
+    @Then("the CHS Kafka API is not invoked")
+    public void chs_kafka_api_not_invoked() throws IOException {
+        verify(disqualifiedApiService, times(0)).invokeChsKafkaApi(any(ResourceChangedRequest.class));
+    }
+
     @Then("the CHS Kafka API is invoked successfully with {string}")
     public void chs_kafka_api_invoked(String officerId) {
         verify(disqualifiedApiService).invokeChsKafkaApi(new ResourceChangedRequest(
-                CucumberContext.CONTEXT.get("contextId"),
-                officerId,
-                CucumberContext.CONTEXT.get("officerType")
+            CucumberContext.CONTEXT.get("contextId"),
+            officerId,
+            CucumberContext.CONTEXT.get("officerType")
         ));
+    }
+
+    @Then("nothing is persisted in the database")
+    public void nothing_persisted_to_database() {
+        List<DisqualificationDocument> disqDoc = repository.findAll();
+        Assertions.assertThat(disqDoc).hasSize(0);
     }
 
     @Then("I should receive {int} status code")

--- a/src/itest/java/uk/gov/companieshouse/disqualifiedofficersdataapi/steps/DisqualificationSteps.java
+++ b/src/itest/java/uk/gov/companieshouse/disqualifiedofficersdataapi/steps/DisqualificationSteps.java
@@ -3,6 +3,7 @@ package uk.gov.companieshouse.disqualifiedofficersdataapi.steps;
 import java.io.IOException;
 import java.util.List;
 
+import com.github.dockerjava.api.exception.InternalServerErrorException;
 import io.cucumber.java.en.*;
 import org.assertj.core.api.Assertions;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -10,7 +11,6 @@ import org.springframework.boot.test.web.client.TestRestTemplate;
 import uk.gov.companieshouse.disqualifiedofficersdataapi.api.DisqualifiedOfficerApiService;
 import uk.gov.companieshouse.disqualifiedofficersdataapi.api.ResourceChangedRequest;
 import uk.gov.companieshouse.disqualifiedofficersdataapi.config.CucumberContext;
-import uk.gov.companieshouse.disqualifiedofficersdataapi.exceptions.InternalServerErrorException;
 import uk.gov.companieshouse.disqualifiedofficersdataapi.exceptions.ServiceUnavailableException;
 import uk.gov.companieshouse.disqualifiedofficersdataapi.model.DisqualificationDocument;
 import uk.gov.companieshouse.disqualifiedofficersdataapi.repository.DisqualifiedOfficerRepository;

--- a/src/itest/resources/features/officer_disq_status_response_codes.feature
+++ b/src/itest/resources/features/officer_disq_status_response_codes.feature
@@ -1,0 +1,41 @@
+Feature: Respone codes scenarios for disqualification officer
+
+  Scenario Outline: Processing disqualified officers information unsuccessfully
+
+    Given disqualified officers data api service is running
+    When I send natural PUT request with payload "<data>" file
+    Then I should receive <response_code> status code
+    And the CHS Kafka API is not invoked
+    And nothing is persisted in the database
+
+    Examples:
+        | data                                             | response_code |
+        | bad_request_natural                              | 400           |
+
+  Scenario: Processing disqualified officers information unsuccessfully
+
+    Given disqualified officers data api service is running
+    When the api throws an internal server error
+    When I send natural PUT request with payload "natural_disqualified_officer" file
+    Then I should receive 500 status code
+
+  Scenario Outline: Processing disqualified officers information unsuccessfully but saves to database
+
+    Given disqualified officers data api service is running
+    When CHS kafka API service is unavailable
+    When I send natural PUT request with payload "<data>" file
+    Then I should receive 503 status code
+    And the natural Get call response body should match "<result>" file
+    And the CHS Kafka API is invoked successfully with "<officerId>"
+
+    Examples:
+        | data                         | result                                | officerId  |
+        | natural_disqualified_officer | retrieve_natural_disqualified_officer | 1234567890 |
+
+  Scenario: Processing disqualified officers information while database is down
+
+    Given disqualified officers data api service is running
+    And the disqualification database is down
+    When I send natural PUT request with payload "natural_disqualified_officer" file
+    Then I should receive 503 status code
+    And the CHS Kafka API is not invoked

--- a/src/itest/resources/features/officer_disq_status_response_codes.feature
+++ b/src/itest/resources/features/officer_disq_status_response_codes.feature
@@ -4,8 +4,8 @@ Feature: Respone codes scenarios for disqualification officer
 
     Given disqualified officers data api service is running
     When I send natural PUT request with payload "<data>" file
-    And the CHS Kafka API is not invoked
     Then I should receive <response_code> status code
+    And the CHS Kafka API is not invoked
     And nothing is persisted in the database
 
     Examples:

--- a/src/itest/resources/features/officer_disq_status_response_codes.feature
+++ b/src/itest/resources/features/officer_disq_status_response_codes.feature
@@ -1,4 +1,4 @@
-Feature: Respone codes scenarios for disqualification officer
+Feature: Response codes scenarios for disqualification officer
 
   Scenario Outline: Processing disqualified officers information unsuccessfully
 

--- a/src/itest/resources/features/officer_disq_status_response_codes.feature
+++ b/src/itest/resources/features/officer_disq_status_response_codes.feature
@@ -9,10 +9,10 @@ Feature: Respone codes scenarios for disqualification officer
     And nothing is persisted in the database
 
     Examples:
-        | data                                             | response_code |
-        | bad_request_natural                              | 400           |
+        | data                | response_code |
+        | bad_request_natural | 400           |
 
-  Scenario: Processing disqualified officers information unsuccessfully
+  Scenario: Processing disqualified officers information unsuccessfully after internal server error
 
     Given disqualified officers data api service is running
     When the api throws an internal server error

--- a/src/itest/resources/features/officer_disq_status_response_codes.feature
+++ b/src/itest/resources/features/officer_disq_status_response_codes.feature
@@ -4,8 +4,8 @@ Feature: Respone codes scenarios for disqualification officer
 
     Given disqualified officers data api service is running
     When I send natural PUT request with payload "<data>" file
-    Then I should receive <response_code> status code
     And the CHS Kafka API is not invoked
+    Then I should receive <response_code> status code
     And nothing is persisted in the database
 
     Examples:
@@ -16,14 +16,14 @@ Feature: Respone codes scenarios for disqualification officer
 
     Given disqualified officers data api service is running
     When the api throws an internal server error
-    When I send natural PUT request with payload "natural_disqualified_officer" file
+    And I send natural PUT request with payload "natural_disqualified_officer" file
     Then I should receive 500 status code
 
   Scenario Outline: Processing disqualified officers information unsuccessfully but saves to database
 
     Given disqualified officers data api service is running
     When CHS kafka API service is unavailable
-    When I send natural PUT request with payload "<data>" file
+    And I send natural PUT request with payload "<data>" file
     Then I should receive 503 status code
     And the natural Get call response body should match "<result>" file
     And the CHS Kafka API is invoked successfully with "<officerId>"

--- a/src/itest/resources/json/input/bad_request_natural.json
+++ b/src/itest/resources/json/input/bad_request_natural.json
@@ -1,0 +1,53 @@
+{
+    "external_data" : {
+      "person_number" : "2",
+      "date_of_birth" : "2022-04-05T12:51:00.767Z",
+      "etag" : "",
+      "title": "Mr",
+      "forename": "Dust",
+      "middle_name": "Condition Reserve",
+      "surname": "KINDNESSLIQUOR",
+      "honours": "",
+      "nationality": "British",
+      "registered_location": "Britain",
+      "disqualifications" : [
+        {
+          "address": {
+            "premise": "30",
+            "address_line_1": "Lucy Road",
+            "address_line_2": "Skewen",
+            "locality": "Neath",
+            "region": "",
+            "country": "Wales",
+            "postal_code": "SA10 6RR"
+          },
+          "case_identifier" : "INV3975227",
+          "company_names": [
+            "CONSORTIUM TECHNOLOGY LIMITED"
+          ],
+          "court_name" : "Insolvency Service",
+          "disqualification_type" : "UNDERTAKING",
+          "disqualified_from" : "NOT_A_VALID_DATE",
+          "disqualified_until" : "2022-04-05T12:51:00.767Z",
+          "heard_on" : "2022-04-05T12:51:00.767Z",
+          "undertaken_on" : "2022-04-05T12:51:00.767Z",
+          "reason" : {
+            "description_identifier" : "string",
+            "section" : "CDDA 1987",
+            "act" : "7",
+            "article" : "string"
+          }
+        }
+      ],
+      "links" : {
+        "self" : "link"
+      }
+    },
+    "internal_data" : {
+      "delta_at" : null,
+      "officer_id" : "1234567890",
+      "officer_id_raw" : "1234567890",
+      "officer_disq_id" : "1234567890",
+      "officer_detail_id" : "1234567890"
+    }
+  }

--- a/src/main/java/uk/gov/companieshouse/disqualifiedofficersdataapi/api/DisqualifiedOfficerApiService.java
+++ b/src/main/java/uk/gov/companieshouse/disqualifiedofficersdataapi/api/DisqualifiedOfficerApiService.java
@@ -43,7 +43,7 @@ public class DisqualifiedOfficerApiService {
      * @param resourceChangedRequest encapsulates details relating to the updated officer
      * @return the response from the kafka api
      */
-    public ApiResponse<Void>  invokeChsKafkaApi(ResourceChangedRequest resourceChangedRequest) {
+    public ApiResponse<Void> invokeChsKafkaApi(ResourceChangedRequest resourceChangedRequest) {
         InternalApiClient internalApiClient = apiClientService.getInternalApiClient();
         internalApiClient.setBasePath(chsKafkaUrl);
 

--- a/src/main/java/uk/gov/companieshouse/disqualifiedofficersdataapi/exceptions/InternalServerErrorException.java
+++ b/src/main/java/uk/gov/companieshouse/disqualifiedofficersdataapi/exceptions/InternalServerErrorException.java
@@ -1,0 +1,7 @@
+package uk.gov.companieshouse.disqualifiedofficersdataapi.exceptions;
+
+public class InternalServerErrorException extends RuntimeException {
+    public InternalServerErrorException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/disqualifiedofficersdataapi/exceptions/InternalServerErrorException.java
+++ b/src/main/java/uk/gov/companieshouse/disqualifiedofficersdataapi/exceptions/InternalServerErrorException.java
@@ -1,7 +1,0 @@
-package uk.gov.companieshouse.disqualifiedofficersdataapi.exceptions;
-
-public class InternalServerErrorException extends RuntimeException {
-    public InternalServerErrorException(String message) {
-        super(message);
-    }
-}


### PR DESCRIPTION
This PR is to add integration to test for response status codes, this includes a 400 - bad request, 503 - service unavailable and 500 - internal server error.

**Resolves**
- DSND-808