### PR TITLE
Add new delete endpoint and allow call to kafka-api

### DIFF
--- a/routes.yaml
+++ b/routes.yaml
@@ -7,3 +7,4 @@ routes:
   3: ^/disqualified-officers/corporate/(.*)/internal
   4: ^/disqualified-officers/natural/(.*)
   5: ^/disqualified-officers/corporate/(.*)
+  6: ^/disqualified-officers/delete/(.*)/internal

--- a/src/itest/java/uk/gov/companieshouse/disqualifiedofficersdataapi/steps/DisqualificationSteps.java
+++ b/src/itest/java/uk/gov/companieshouse/disqualifiedofficersdataapi/steps/DisqualificationSteps.java
@@ -67,7 +67,8 @@ public class DisqualificationSteps {
             CucumberContext.CONTEXT.get("contextId"),
             officerId,
             CucumberContext.CONTEXT.get("officerType"),
-            null
+            null,
+            false
         ));
     }
 

--- a/src/itest/java/uk/gov/companieshouse/disqualifiedofficersdataapi/steps/DisqualificationSteps.java
+++ b/src/itest/java/uk/gov/companieshouse/disqualifiedofficersdataapi/steps/DisqualificationSteps.java
@@ -30,7 +30,8 @@ public class DisqualificationSteps {
         verify(disqualifiedApiService).invokeChsKafkaApi(new ResourceChangedRequest(
                 CucumberContext.CONTEXT.get("contextId"),
                 officerId,
-                CucumberContext.CONTEXT.get("officerType")
+                CucumberContext.CONTEXT.get("officerType"),
+                null
         ));
     }
 

--- a/src/main/java/uk/gov/companieshouse/disqualifiedofficersdataapi/api/DisqualifiedOfficerApiService.java
+++ b/src/main/java/uk/gov/companieshouse/disqualifiedofficersdataapi/api/DisqualifiedOfficerApiService.java
@@ -1,6 +1,7 @@
 package uk.gov.companieshouse.disqualifiedofficersdataapi.api;
 
 import java.util.function.Function;
+import java.util.function.BiFunction;
 import java.util.function.Supplier;
 
 import org.springframework.beans.factory.annotation.Value;
@@ -13,6 +14,8 @@ import uk.gov.companieshouse.api.handler.chskafka.request.PrivateChangedResource
 import uk.gov.companieshouse.api.model.ApiResponse;
 import uk.gov.companieshouse.disqualifiedofficersdataapi.exceptions.MethodNotAllowedException;
 import uk.gov.companieshouse.disqualifiedofficersdataapi.exceptions.ServiceUnavailableException;
+import uk.gov.companieshouse.disqualifiedofficersdataapi.model.CorporateDisqualificationDocument;
+import uk.gov.companieshouse.disqualifiedofficersdataapi.model.NaturalDisqualificationDocument;
 import uk.gov.companieshouse.logging.Logger;
 
 @Service
@@ -23,6 +26,8 @@ public class DisqualifiedOfficerApiService {
     private final String chsKafkaUrl;
     private final ApiClientService apiClientService;
     private final Function<ResourceChangedRequest, ChangedResource> mapper;
+    private final BiFunction<ResourceChangedRequest, CorporateDisqualificationDocument, ChangedResource> corpDeleteMapper;
+    private final BiFunction<ResourceChangedRequest, NaturalDisqualificationDocument, ChangedResource> natDeleteMapper;
 
     /**
      * Invoke API.
@@ -31,16 +36,21 @@ public class DisqualifiedOfficerApiService {
             ApiClientService apiClientService,
             Logger logger,
             Supplier<String> timestampGenerator,
-            Function<ResourceChangedRequest, ChangedResource> mapper) {
+            Function<ResourceChangedRequest, ChangedResource> mapper,
+            BiFunction<ResourceChangedRequest, CorporateDisqualificationDocument, ChangedResource> corpDeleteMapper,
+            BiFunction<ResourceChangedRequest, NaturalDisqualificationDocument, ChangedResource> natDeleteMapper) {
         this.chsKafkaUrl = chsKafkaUrl;
         this.apiClientService = apiClientService;
         this.logger = logger;
         this.mapper = mapper;
+        this.corpDeleteMapper = corpDeleteMapper;
+        this.natDeleteMapper = natDeleteMapper;
     }
+
 
     /**
      * Calls the CHS Kafka api.
-     * @param resourceChangedRequest encapsulates details relating to the updated officer
+     * @param resourceChangedRequest encapsulates details relating to the updated or deleted officer
      * @return the response from the kafka api
      */
     public ApiResponse<Void>  invokeChsKafkaApi(ResourceChangedRequest resourceChangedRequest) {
@@ -51,6 +61,46 @@ public class DisqualifiedOfficerApiService {
                 internalApiClient.privateChangedResourceHandler().postChangedResource(
                         CHANGED_RESOURCE_URI, mapper.apply(resourceChangedRequest));
 
+        return handleApiCall(changedResourcePost);
+    }
+
+    /**
+     * Calls the CHS Kafka api.
+     * @param resourceChangedRequest encapsulates details relating to the updated or deleted officer
+     * @param document corporate disqualification document used to pass api object to deleted data
+     * @return the response from the kafka api
+     */
+    public ApiResponse<Void>  invokeChsKafkaApi(ResourceChangedRequest resourceChangedRequest,
+            CorporateDisqualificationDocument document) {
+        InternalApiClient internalApiClient = apiClientService.getInternalApiClient();
+        internalApiClient.setBasePath(chsKafkaUrl);
+
+        PrivateChangedResourcePost changedResourcePost =
+                internalApiClient.privateChangedResourceHandler().postChangedResource(
+                        CHANGED_RESOURCE_URI, corpDeleteMapper.apply(resourceChangedRequest, document));
+
+        return handleApiCall(changedResourcePost);
+    }
+
+    /**
+     * Calls the CHS Kafka api.
+     * @param resourceChangedRequest encapsulates details relating to the updated or deleted officer
+     * @param document natural disqualification document used to pass api object to deleted data
+     * @return the response from the kafka api
+     */
+    public ApiResponse<Void>  invokeChsKafkaApi(ResourceChangedRequest resourceChangedRequest,
+            NaturalDisqualificationDocument document) {
+        InternalApiClient internalApiClient = apiClientService.getInternalApiClient();
+        internalApiClient.setBasePath(chsKafkaUrl);
+
+        PrivateChangedResourcePost changedResourcePost =
+                internalApiClient.privateChangedResourceHandler().postChangedResource(
+                        CHANGED_RESOURCE_URI, natDeleteMapper.apply(resourceChangedRequest, document));
+
+        return handleApiCall(changedResourcePost);
+    }
+
+    private ApiResponse<Void> handleApiCall(PrivateChangedResourcePost changedResourcePost) {
         try {
             return changedResourcePost.execute();
         } catch (ApiErrorResponseException exp) {

--- a/src/main/java/uk/gov/companieshouse/disqualifiedofficersdataapi/api/ResourceChangedRequest.java
+++ b/src/main/java/uk/gov/companieshouse/disqualifiedofficersdataapi/api/ResourceChangedRequest.java
@@ -45,7 +45,7 @@ public class ResourceChangedRequest {
         ResourceChangedRequest that = (ResourceChangedRequest) o;
         return Objects.equals(contextId, that.contextId) && Objects.equals(
                 officerId, that.officerId) && type == that.type && 
-                this.disqualificationData == that.disqualificationData;
+                disqualificationData == that.disqualificationData;
     }
 
     @Override

--- a/src/main/java/uk/gov/companieshouse/disqualifiedofficersdataapi/api/ResourceChangedRequest.java
+++ b/src/main/java/uk/gov/companieshouse/disqualifiedofficersdataapi/api/ResourceChangedRequest.java
@@ -9,13 +9,15 @@ public class ResourceChangedRequest {
     private final String officerId;
     private final DisqualificationResourceType type;
     private final Object disqualificationData;
+    private final Boolean isDelete;
 
     public ResourceChangedRequest(String contextId, String officerId, DisqualificationResourceType type, 
-            Object disqualificationData) {
+            Object disqualificationData, Boolean isDelete) {
         this.contextId = contextId;
         this.officerId = officerId;
         this.type = type;
         this.disqualificationData = disqualificationData;
+        this.isDelete = isDelete;
     }
 
     public String getContextId() {
@@ -34,6 +36,10 @@ public class ResourceChangedRequest {
         return disqualificationData;
     }
 
+    public Boolean getIsDelete() {
+        return isDelete;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) {
@@ -44,12 +50,13 @@ public class ResourceChangedRequest {
         }
         ResourceChangedRequest that = (ResourceChangedRequest) o;
         return Objects.equals(contextId, that.contextId) && Objects.equals(
-                officerId, that.officerId) && type == that.type && 
-                disqualificationData == that.disqualificationData;
+                officerId, that.officerId) && type == that.type &&
+                disqualificationData == that.disqualificationData &&
+                isDelete == that.isDelete;
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(contextId, officerId, type, disqualificationData);
+        return Objects.hash(contextId, officerId, type, disqualificationData, isDelete);
     }
 }

--- a/src/main/java/uk/gov/companieshouse/disqualifiedofficersdataapi/api/ResourceChangedRequest.java
+++ b/src/main/java/uk/gov/companieshouse/disqualifiedofficersdataapi/api/ResourceChangedRequest.java
@@ -8,11 +8,14 @@ public class ResourceChangedRequest {
     private final String contextId;
     private final String officerId;
     private final DisqualificationResourceType type;
+    private final Object disqualificationData;
 
-    public ResourceChangedRequest(String contextId, String officerId, DisqualificationResourceType type) {
+    public ResourceChangedRequest(String contextId, String officerId, DisqualificationResourceType type, 
+            Object disqualificationData) {
         this.contextId = contextId;
         this.officerId = officerId;
         this.type = type;
+        this.disqualificationData = disqualificationData;
     }
 
     public String getContextId() {
@@ -27,6 +30,10 @@ public class ResourceChangedRequest {
         return type;
     }
 
+    public Object getDisqualificationData() {
+        return disqualificationData;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) {
@@ -37,11 +44,12 @@ public class ResourceChangedRequest {
         }
         ResourceChangedRequest that = (ResourceChangedRequest) o;
         return Objects.equals(contextId, that.contextId) && Objects.equals(
-                officerId, that.officerId) && type == that.type;
+                officerId, that.officerId) && type == that.type && 
+                this.disqualificationData == that.disqualificationData;
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(contextId, officerId, type);
+        return Objects.hash(contextId, officerId, type, disqualificationData);
     }
 }

--- a/src/main/java/uk/gov/companieshouse/disqualifiedofficersdataapi/api/ResourceChangedRequestMapper.java
+++ b/src/main/java/uk/gov/companieshouse/disqualifiedofficersdataapi/api/ResourceChangedRequestMapper.java
@@ -29,7 +29,7 @@ public class ResourceChangedRequestMapper {
         }
 
         ChangedResourceEvent event = new ChangedResourceEvent();
-        if (request.getDisqualificationData() != null) {
+        if (request.getIsDelete()) {
             event.setType("deleted");
             changedResource.setDeletedData(request.getDisqualificationData());
         } else {

--- a/src/main/java/uk/gov/companieshouse/disqualifiedofficersdataapi/api/ResourceChangedRequestMapper.java
+++ b/src/main/java/uk/gov/companieshouse/disqualifiedofficersdataapi/api/ResourceChangedRequestMapper.java
@@ -1,9 +1,13 @@
 package uk.gov.companieshouse.disqualifiedofficersdataapi.api;
 
 import java.util.function.Supplier;
+
 import uk.gov.companieshouse.api.chskafka.ChangedResource;
 import uk.gov.companieshouse.api.chskafka.ChangedResourceEvent;
+import uk.gov.companieshouse.disqualifiedofficersdataapi.model.CorporateDisqualificationDocument;
 import uk.gov.companieshouse.disqualifiedofficersdataapi.model.DisqualificationResourceType;
+import uk.gov.companieshouse.disqualifiedofficersdataapi.model.NaturalDisqualificationDocument;
+
 
 public class ResourceChangedRequestMapper {
 
@@ -28,6 +32,39 @@ public class ResourceChangedRequestMapper {
 
         ChangedResourceEvent event = new ChangedResourceEvent();
         event.setType("changed");
+        event.publishedAt(this.timestampGenerator.get());
+
+        changedResource.event(event);
+        changedResource.setContextId(request.getContextId());
+
+        return changedResource;
+    }
+
+    public ChangedResource mapChangedResource(ResourceChangedRequest request, CorporateDisqualificationDocument document) {
+        ChangedResource changedResource = new ChangedResource();
+
+        changedResource.setResourceUri("/disqualified-officers/corporate/" + request.getOfficerId());
+        changedResource.setResourceKind("disqualified-officer-corporate");
+
+        ChangedResourceEvent event = new ChangedResourceEvent();
+        event.setType("deleted");
+        changedResource.setDeletedData(document.getData());
+        event.publishedAt(this.timestampGenerator.get());
+
+        changedResource.event(event);
+        changedResource.setContextId(request.getContextId());
+
+        return changedResource;
+    }
+
+    public ChangedResource mapChangedResource(ResourceChangedRequest request, NaturalDisqualificationDocument document) {
+        ChangedResource changedResource = new ChangedResource();
+        changedResource.setResourceUri("/disqualified-officers/natural/" + request.getOfficerId());
+        changedResource.setResourceKind("disqualified-officer-natural");
+
+        ChangedResourceEvent event = new ChangedResourceEvent();
+        event.setType("deleted");
+        changedResource.setDeletedData(document.getData());
         event.publishedAt(this.timestampGenerator.get());
 
         changedResource.event(event);

--- a/src/main/java/uk/gov/companieshouse/disqualifiedofficersdataapi/api/ResourceChangedRequestMapper.java
+++ b/src/main/java/uk/gov/companieshouse/disqualifiedofficersdataapi/api/ResourceChangedRequestMapper.java
@@ -4,9 +4,7 @@ import java.util.function.Supplier;
 
 import uk.gov.companieshouse.api.chskafka.ChangedResource;
 import uk.gov.companieshouse.api.chskafka.ChangedResourceEvent;
-import uk.gov.companieshouse.disqualifiedofficersdataapi.model.CorporateDisqualificationDocument;
 import uk.gov.companieshouse.disqualifiedofficersdataapi.model.DisqualificationResourceType;
-import uk.gov.companieshouse.disqualifiedofficersdataapi.model.NaturalDisqualificationDocument;
 
 
 public class ResourceChangedRequestMapper {
@@ -31,40 +29,12 @@ public class ResourceChangedRequestMapper {
         }
 
         ChangedResourceEvent event = new ChangedResourceEvent();
-        event.setType("changed");
-        event.publishedAt(this.timestampGenerator.get());
-
-        changedResource.event(event);
-        changedResource.setContextId(request.getContextId());
-
-        return changedResource;
-    }
-
-    public ChangedResource mapChangedResource(ResourceChangedRequest request, CorporateDisqualificationDocument document) {
-        ChangedResource changedResource = new ChangedResource();
-
-        changedResource.setResourceUri("/disqualified-officers/corporate/" + request.getOfficerId());
-        changedResource.setResourceKind("disqualified-officer-corporate");
-
-        ChangedResourceEvent event = new ChangedResourceEvent();
-        event.setType("deleted");
-        changedResource.setDeletedData(document.getData());
-        event.publishedAt(this.timestampGenerator.get());
-
-        changedResource.event(event);
-        changedResource.setContextId(request.getContextId());
-
-        return changedResource;
-    }
-
-    public ChangedResource mapChangedResource(ResourceChangedRequest request, NaturalDisqualificationDocument document) {
-        ChangedResource changedResource = new ChangedResource();
-        changedResource.setResourceUri("/disqualified-officers/natural/" + request.getOfficerId());
-        changedResource.setResourceKind("disqualified-officer-natural");
-
-        ChangedResourceEvent event = new ChangedResourceEvent();
-        event.setType("deleted");
-        changedResource.setDeletedData(document.getData());
+        if (request.getDisqualificationData() != null) {
+            event.setType("deleted");
+            changedResource.setDeletedData(request.getDisqualificationData());
+        } else {
+            event.setType("changed");
+        }
         event.publishedAt(this.timestampGenerator.get());
 
         changedResource.event(event);

--- a/src/main/java/uk/gov/companieshouse/disqualifiedofficersdataapi/config/ApplicationConfig.java
+++ b/src/main/java/uk/gov/companieshouse/disqualifiedofficersdataapi/config/ApplicationConfig.java
@@ -7,7 +7,6 @@ import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.databind.module.SimpleModule;
 
 import java.util.function.Function;
-import java.util.function.BiFunction;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.mongodb.core.convert.MongoCustomConversions;
@@ -18,8 +17,6 @@ import uk.gov.companieshouse.disqualifiedofficersdataapi.converter.DisqualifiedC
 import uk.gov.companieshouse.disqualifiedofficersdataapi.converter.DisqualifiedCorporateOfficerWriteConverter;
 import uk.gov.companieshouse.disqualifiedofficersdataapi.converter.DisqualifiedNaturalOfficerReadConverter;
 import uk.gov.companieshouse.disqualifiedofficersdataapi.converter.DisqualifiedNaturalOfficerWriteConverter;
-import uk.gov.companieshouse.disqualifiedofficersdataapi.model.CorporateDisqualificationDocument;
-import uk.gov.companieshouse.disqualifiedofficersdataapi.model.NaturalDisqualificationDocument;
 import uk.gov.companieshouse.disqualifiedofficersdataapi.serialization.LocalDateDeSerializer;
 import uk.gov.companieshouse.disqualifiedofficersdataapi.serialization.LocalDateSerializer;
 
@@ -52,18 +49,6 @@ public class ApplicationConfig {
 
     @Bean
     public Function<ResourceChangedRequest, ChangedResource> mapper() {
-        ResourceChangedRequestMapper mapper = new ResourceChangedRequestMapper(offsetDateTimeGenerator());
-        return mapper::mapChangedResource;
-    }
-
-    @Bean
-    public BiFunction<ResourceChangedRequest, CorporateDisqualificationDocument, ChangedResource> corporateMapper() {
-        ResourceChangedRequestMapper mapper = new ResourceChangedRequestMapper(offsetDateTimeGenerator());
-        return mapper::mapChangedResource;
-    }
-
-    @Bean
-    public BiFunction<ResourceChangedRequest, NaturalDisqualificationDocument, ChangedResource> naturalMapper() {
         ResourceChangedRequestMapper mapper = new ResourceChangedRequestMapper(offsetDateTimeGenerator());
         return mapper::mapChangedResource;
     }

--- a/src/main/java/uk/gov/companieshouse/disqualifiedofficersdataapi/config/ApplicationConfig.java
+++ b/src/main/java/uk/gov/companieshouse/disqualifiedofficersdataapi/config/ApplicationConfig.java
@@ -5,7 +5,9 @@ import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.databind.module.SimpleModule;
+
 import java.util.function.Function;
+import java.util.function.BiFunction;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.mongodb.core.convert.MongoCustomConversions;
@@ -16,6 +18,8 @@ import uk.gov.companieshouse.disqualifiedofficersdataapi.converter.DisqualifiedC
 import uk.gov.companieshouse.disqualifiedofficersdataapi.converter.DisqualifiedCorporateOfficerWriteConverter;
 import uk.gov.companieshouse.disqualifiedofficersdataapi.converter.DisqualifiedNaturalOfficerReadConverter;
 import uk.gov.companieshouse.disqualifiedofficersdataapi.converter.DisqualifiedNaturalOfficerWriteConverter;
+import uk.gov.companieshouse.disqualifiedofficersdataapi.model.CorporateDisqualificationDocument;
+import uk.gov.companieshouse.disqualifiedofficersdataapi.model.NaturalDisqualificationDocument;
 import uk.gov.companieshouse.disqualifiedofficersdataapi.serialization.LocalDateDeSerializer;
 import uk.gov.companieshouse.disqualifiedofficersdataapi.serialization.LocalDateSerializer;
 
@@ -48,6 +52,18 @@ public class ApplicationConfig {
 
     @Bean
     public Function<ResourceChangedRequest, ChangedResource> mapper() {
+        ResourceChangedRequestMapper mapper = new ResourceChangedRequestMapper(offsetDateTimeGenerator());
+        return mapper::mapChangedResource;
+    }
+
+    @Bean
+    public BiFunction<ResourceChangedRequest, CorporateDisqualificationDocument, ChangedResource> corporateMapper() {
+        ResourceChangedRequestMapper mapper = new ResourceChangedRequestMapper(offsetDateTimeGenerator());
+        return mapper::mapChangedResource;
+    }
+
+    @Bean
+    public BiFunction<ResourceChangedRequest, NaturalDisqualificationDocument, ChangedResource> naturalMapper() {
         ResourceChangedRequestMapper mapper = new ResourceChangedRequestMapper(offsetDateTimeGenerator());
         return mapper::mapChangedResource;
     }

--- a/src/main/java/uk/gov/companieshouse/disqualifiedofficersdataapi/controller/DisqualifiedOfficerController.java
+++ b/src/main/java/uk/gov/companieshouse/disqualifiedofficersdataapi/controller/DisqualifiedOfficerController.java
@@ -131,7 +131,7 @@ public class DisqualifiedOfficerController {
     /**
      * Delete disqualification information for an officer id.
      *
-     * @param  officer_id  the officer id to be deleted
+     * @param  officerId  the officer id to be deleted
      * @return return 200 status with empty body
      */
     @DeleteMapping("/disqualified-officers/delete/{officer_id}/internal")
@@ -139,9 +139,8 @@ public class DisqualifiedOfficerController {
             @RequestHeader("x-request-id") String contextId,
             @PathVariable("officer_id") String officerId) {
         logger.info(String.format(
-                "Deleting disqualified officer information for officer id %s",
-                officerId));
-                service.deleteDisqualification(contextId, officerId);
+                "Deleting disqualified officer information for officer id %s", officerId));
+        service.deleteDisqualification(contextId, officerId);
         return ResponseEntity.status(HttpStatus.OK).build();
     }
 }

--- a/src/main/java/uk/gov/companieshouse/disqualifiedofficersdataapi/controller/DisqualifiedOfficerController.java
+++ b/src/main/java/uk/gov/companieshouse/disqualifiedofficersdataapi/controller/DisqualifiedOfficerController.java
@@ -4,7 +4,13 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RestController;
 
 import uk.gov.companieshouse.api.disqualification.CorporateDisqualificationApi;
 import uk.gov.companieshouse.api.disqualification.InternalCorporateDisqualificationApi;
@@ -120,5 +126,22 @@ public class DisqualifiedOfficerController {
         data.setPersonNumber(null);
 
         return ResponseEntity.status(HttpStatus.OK).body(disqualification.getData());
+    }
+
+    /**
+     * Delete disqualification information for an officer id.
+     *
+     * @param  officer_id  the officer id to be deleted
+     * @return return 200 status with empty body
+     */
+    @DeleteMapping("/disqualified-officers/delete/{officer_id}/internal")
+    public ResponseEntity<Void> deleteDisqualification(
+            @RequestHeader("x-request-id") String contextId,
+            @PathVariable("officer_id") String officerId) {
+        logger.info(String.format(
+                "Deleting disqualified officer information for officer id %s",
+                officerId));
+                service.deleteDisqualification(contextId, officerId);
+        return ResponseEntity.status(HttpStatus.OK).build();
     }
 }

--- a/src/main/java/uk/gov/companieshouse/disqualifiedofficersdataapi/service/DisqualifiedOfficerService.java
+++ b/src/main/java/uk/gov/companieshouse/disqualifiedofficersdataapi/service/DisqualifiedOfficerService.java
@@ -101,7 +101,8 @@ public class DisqualifiedOfficerService {
         CorporateDisqualificationDocument document = retrieveCorporateDisqualification(officerId);
         repository.delete(document);
         disqualifiedOfficerApiService.invokeChsKafkaApi(
-                new ResourceChangedRequest(contextId, officerId, DisqualificationResourceType.CORPORATE), document);
+                new ResourceChangedRequest(contextId, officerId, 
+                        DisqualificationResourceType.CORPORATE, document.getData()));
     }
 
     /**
@@ -113,7 +114,8 @@ public class DisqualifiedOfficerService {
         NaturalDisqualificationDocument document = retrieveNaturalDisqualification(officerId);
         repository.delete(document);
         disqualifiedOfficerApiService.invokeChsKafkaApi(
-                new ResourceChangedRequest(contextId, officerId, DisqualificationResourceType.NATURAL), document);
+                new ResourceChangedRequest(contextId, officerId, 
+                        DisqualificationResourceType.NATURAL, document.getData()));
     }
 
     /**
@@ -153,7 +155,9 @@ public class DisqualifiedOfficerService {
         }
         
         if (savedToDb) {
-            disqualifiedOfficerApiService.invokeChsKafkaApi(new ResourceChangedRequest(contextId, officerId, type));
+            disqualifiedOfficerApiService.invokeChsKafkaApi(
+                    new ResourceChangedRequest(contextId, officerId, 
+                            type, null));
         }
     }
 

--- a/src/main/java/uk/gov/companieshouse/disqualifiedofficersdataapi/service/DisqualifiedOfficerService.java
+++ b/src/main/java/uk/gov/companieshouse/disqualifiedofficersdataapi/service/DisqualifiedOfficerService.java
@@ -102,7 +102,7 @@ public class DisqualifiedOfficerService {
         repository.delete(document);
         disqualifiedOfficerApiService.invokeChsKafkaApi(
                 new ResourceChangedRequest(contextId, officerId, 
-                        DisqualificationResourceType.CORPORATE, document.getData()));
+                        DisqualificationResourceType.CORPORATE, document.getData(), true));
     }
 
     /**
@@ -115,7 +115,7 @@ public class DisqualifiedOfficerService {
         repository.delete(document);
         disqualifiedOfficerApiService.invokeChsKafkaApi(
                 new ResourceChangedRequest(contextId, officerId, 
-                        DisqualificationResourceType.NATURAL, document.getData()));
+                        DisqualificationResourceType.NATURAL, document.getData(), true));
     }
 
     /**
@@ -157,7 +157,7 @@ public class DisqualifiedOfficerService {
         if (savedToDb) {
             disqualifiedOfficerApiService.invokeChsKafkaApi(
                     new ResourceChangedRequest(contextId, officerId, 
-                            type, null));
+                            type, null, false));
         }
     }
 

--- a/src/test/java/uk/gov/companieshouse/disqualifiedofficersdataapi/api/DisqualifiedOfficerApiClientServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/disqualifiedofficersdataapi/api/DisqualifiedOfficerApiClientServiceTest.java
@@ -2,6 +2,8 @@ package uk.gov.companieshouse.disqualifiedofficersdataapi.api;
 
 import com.google.api.client.http.HttpHeaders;
 import com.google.api.client.http.HttpResponseException;
+
+import java.util.function.BiFunction;
 import java.util.function.Function;
 import org.assertj.core.api.Assertions;
 import org.junit.Assert;
@@ -16,12 +18,14 @@ import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.companieshouse.api.InternalApiClient;
 import uk.gov.companieshouse.api.chskafka.ChangedResource;
+import uk.gov.companieshouse.api.disqualification.CorporateDisqualificationApi;
 import uk.gov.companieshouse.api.error.ApiErrorResponseException;
 import uk.gov.companieshouse.api.handler.chskafka.PrivateChangedResourceHandler;
 import uk.gov.companieshouse.api.handler.chskafka.request.PrivateChangedResourcePost;
 import uk.gov.companieshouse.api.model.ApiResponse;
 import uk.gov.companieshouse.disqualifiedofficersdataapi.exceptions.MethodNotAllowedException;
 import uk.gov.companieshouse.disqualifiedofficersdataapi.exceptions.ServiceUnavailableException;
+import uk.gov.companieshouse.disqualifiedofficersdataapi.model.CorporateDisqualificationDocument;
 import uk.gov.companieshouse.disqualifiedofficersdataapi.model.DisqualificationResourceType;
 import uk.gov.companieshouse.logging.Logger;
 
@@ -58,6 +62,9 @@ public class DisqualifiedOfficerApiClientServiceTest {
     private Function<ResourceChangedRequest, ChangedResource> mapper;
 
     @Mock
+    private BiFunction<ResourceChangedRequest, CorporateDisqualificationDocument, ChangedResource> corpDeleteMapper;
+
+    @Mock
     private ResourceChangedRequest resourceChangedRequest;
 
     @Mock
@@ -76,6 +83,27 @@ public class DisqualifiedOfficerApiClientServiceTest {
 
         ApiResponse<?> apiResponse =
                 disqualifiedOfficerApiService.invokeChsKafkaApi(resourceChangedRequest);
+
+        Assertions.assertThat(apiResponse).isNotNull();
+
+        verify(apiClientService, times(1)).getInternalApiClient();
+        verify(internalApiClient, times(1)).privateChangedResourceHandler();
+        verify(privateChangedResourceHandler, times(1)).postChangedResource("/resource-changed", changedResource);
+        verify(changedResourcePost, times(1)).execute();
+    }
+
+    @Test
+    void corp_delete_should_invoke_chs_kafka_endpoint_successfully() throws ApiErrorResponseException {
+        CorporateDisqualificationDocument document = new CorporateDisqualificationDocument();
+        document.setData(new CorporateDisqualificationApi());
+        when(apiClientService.getInternalApiClient()).thenReturn(internalApiClient);
+        when(corpDeleteMapper.apply(resourceChangedRequest, document)).thenReturn(changedResource);
+        when(internalApiClient.privateChangedResourceHandler()).thenReturn(privateChangedResourceHandler);
+        when(privateChangedResourceHandler.postChangedResource(Mockito.any(), Mockito.any())).thenReturn(changedResourcePost);
+        when(changedResourcePost.execute()).thenReturn(response);
+
+        ApiResponse<?> apiResponse =
+                disqualifiedOfficerApiService.invokeChsKafkaApi(resourceChangedRequest, document);
 
         Assertions.assertThat(apiResponse).isNotNull();
 

--- a/src/test/java/uk/gov/companieshouse/disqualifiedofficersdataapi/api/DisqualifiedOfficerApiClientServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/disqualifiedofficersdataapi/api/DisqualifiedOfficerApiClientServiceTest.java
@@ -97,7 +97,7 @@ public class DisqualifiedOfficerApiClientServiceTest {
 
         Assert.assertThrows(RuntimeException.class, () -> disqualifiedOfficerApiService.invokeChsKafkaApi
                 (new ResourceChangedRequest("3245435", "CH4000056",
-                        DisqualificationResourceType.NATURAL, null)));
+                        DisqualificationResourceType.NATURAL, null, false)));
 
         verify(apiClientService, times(1)).getInternalApiClient();
         verify(internalApiClient, times(1)).privateChangedResourceHandler();

--- a/src/test/java/uk/gov/companieshouse/disqualifiedofficersdataapi/api/DisqualifiedOfficerApiClientServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/disqualifiedofficersdataapi/api/DisqualifiedOfficerApiClientServiceTest.java
@@ -3,7 +3,6 @@ package uk.gov.companieshouse.disqualifiedofficersdataapi.api;
 import com.google.api.client.http.HttpHeaders;
 import com.google.api.client.http.HttpResponseException;
 
-import java.util.function.BiFunction;
 import java.util.function.Function;
 import org.assertj.core.api.Assertions;
 import org.junit.Assert;
@@ -18,14 +17,12 @@ import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.companieshouse.api.InternalApiClient;
 import uk.gov.companieshouse.api.chskafka.ChangedResource;
-import uk.gov.companieshouse.api.disqualification.CorporateDisqualificationApi;
 import uk.gov.companieshouse.api.error.ApiErrorResponseException;
 import uk.gov.companieshouse.api.handler.chskafka.PrivateChangedResourceHandler;
 import uk.gov.companieshouse.api.handler.chskafka.request.PrivateChangedResourcePost;
 import uk.gov.companieshouse.api.model.ApiResponse;
 import uk.gov.companieshouse.disqualifiedofficersdataapi.exceptions.MethodNotAllowedException;
 import uk.gov.companieshouse.disqualifiedofficersdataapi.exceptions.ServiceUnavailableException;
-import uk.gov.companieshouse.disqualifiedofficersdataapi.model.CorporateDisqualificationDocument;
 import uk.gov.companieshouse.disqualifiedofficersdataapi.model.DisqualificationResourceType;
 import uk.gov.companieshouse.logging.Logger;
 
@@ -62,9 +59,6 @@ public class DisqualifiedOfficerApiClientServiceTest {
     private Function<ResourceChangedRequest, ChangedResource> mapper;
 
     @Mock
-    private BiFunction<ResourceChangedRequest, CorporateDisqualificationDocument, ChangedResource> corpDeleteMapper;
-
-    @Mock
     private ResourceChangedRequest resourceChangedRequest;
 
     @Mock
@@ -93,27 +87,6 @@ public class DisqualifiedOfficerApiClientServiceTest {
     }
 
     @Test
-    void corp_delete_should_invoke_chs_kafka_endpoint_successfully() throws ApiErrorResponseException {
-        CorporateDisqualificationDocument document = new CorporateDisqualificationDocument();
-        document.setData(new CorporateDisqualificationApi());
-        when(apiClientService.getInternalApiClient()).thenReturn(internalApiClient);
-        when(corpDeleteMapper.apply(resourceChangedRequest, document)).thenReturn(changedResource);
-        when(internalApiClient.privateChangedResourceHandler()).thenReturn(privateChangedResourceHandler);
-        when(privateChangedResourceHandler.postChangedResource(Mockito.any(), Mockito.any())).thenReturn(changedResourcePost);
-        when(changedResourcePost.execute()).thenReturn(response);
-
-        ApiResponse<?> apiResponse =
-                disqualifiedOfficerApiService.invokeChsKafkaApi(resourceChangedRequest, document);
-
-        Assertions.assertThat(apiResponse).isNotNull();
-
-        verify(apiClientService, times(1)).getInternalApiClient();
-        verify(internalApiClient, times(1)).privateChangedResourceHandler();
-        verify(privateChangedResourceHandler, times(1)).postChangedResource("/resource-changed", changedResource);
-        verify(changedResourcePost, times(1)).execute();
-    }
-
-    @Test
     void should_handle_exception_when_chs_kafka_endpoint_throws_exception() throws ApiErrorResponseException {
 
         when(apiClientService.getInternalApiClient()).thenReturn(internalApiClient);
@@ -124,7 +97,7 @@ public class DisqualifiedOfficerApiClientServiceTest {
 
         Assert.assertThrows(RuntimeException.class, () -> disqualifiedOfficerApiService.invokeChsKafkaApi
                 (new ResourceChangedRequest("3245435", "CH4000056",
-                        DisqualificationResourceType.NATURAL)));
+                        DisqualificationResourceType.NATURAL, null)));
 
         verify(apiClientService, times(1)).getInternalApiClient();
         verify(internalApiClient, times(1)).privateChangedResourceHandler();

--- a/src/test/java/uk/gov/companieshouse/disqualifiedofficersdataapi/api/ResourceChangedRequestMapperTest.java
+++ b/src/test/java/uk/gov/companieshouse/disqualifiedofficersdataapi/api/ResourceChangedRequestMapperTest.java
@@ -62,7 +62,7 @@ public class ResourceChangedRequestMapperTest {
     static Stream<ResourceChangedTestArgument> resourceChangedScenarios() {
         return Stream.of(
                 ResourceChangedTestArgument.builder()
-                        .withRequest(new ResourceChangedRequest(EXPECTED_CONTEXT_ID, "CH4000056", DisqualificationResourceType.NATURAL, null))
+                        .withRequest(new ResourceChangedRequest(EXPECTED_CONTEXT_ID, "CH4000056", DisqualificationResourceType.NATURAL, null, false))
                         .withContextId(EXPECTED_CONTEXT_ID)
                         .withResourceUri("/disqualified-officers/natural/CH4000056")
                         .withResourceKind("disqualified-officer-natural")
@@ -70,7 +70,7 @@ public class ResourceChangedRequestMapperTest {
                         .withEventPublishedAt(DATE)
                         .build(),
                 ResourceChangedTestArgument.builder()
-                        .withRequest(new ResourceChangedRequest(EXPECTED_CONTEXT_ID, "CH4000056", DisqualificationResourceType.CORPORATE, null))
+                        .withRequest(new ResourceChangedRequest(EXPECTED_CONTEXT_ID, "CH4000056", DisqualificationResourceType.CORPORATE, null, false))
                         .withContextId(EXPECTED_CONTEXT_ID)
                         .withResourceUri("/disqualified-officers/corporate/CH4000056")
                         .withResourceKind("disqualified-officer-corporate")
@@ -78,7 +78,7 @@ public class ResourceChangedRequestMapperTest {
                         .withEventPublishedAt(DATE)
                         .build(),
                 ResourceChangedTestArgument.builder()
-                        .withRequest(new ResourceChangedRequest(EXPECTED_CONTEXT_ID, "CH4000056", DisqualificationResourceType.CORPORATE, new CorporateDisqualificationApi()))
+                        .withRequest(new ResourceChangedRequest(EXPECTED_CONTEXT_ID, "CH4000056", DisqualificationResourceType.CORPORATE, new CorporateDisqualificationApi(), true))
                         .withContextId(EXPECTED_CONTEXT_ID)
                         .withResourceUri("/disqualified-officers/corporate/CH4000056")
                         .withResourceKind("disqualified-officer-corporate")
@@ -87,7 +87,7 @@ public class ResourceChangedRequestMapperTest {
                         .withDeletedData(new CorporateDisqualificationApi())
                         .build(),
                 ResourceChangedTestArgument.builder()
-                        .withRequest(new ResourceChangedRequest(EXPECTED_CONTEXT_ID, "CH4000056", DisqualificationResourceType.NATURAL, new NaturalDisqualificationApi()))
+                        .withRequest(new ResourceChangedRequest(EXPECTED_CONTEXT_ID, "CH4000056", DisqualificationResourceType.NATURAL, new NaturalDisqualificationApi(), true))
                         .withContextId(EXPECTED_CONTEXT_ID)
                         .withResourceUri("/disqualified-officers/natural/CH4000056")
                         .withResourceKind("disqualified-officer-natural")

--- a/src/test/java/uk/gov/companieshouse/disqualifiedofficersdataapi/api/ResourceChangedRequestMapperTest.java
+++ b/src/test/java/uk/gov/companieshouse/disqualifiedofficersdataapi/api/ResourceChangedRequestMapperTest.java
@@ -17,9 +17,9 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.companieshouse.api.chskafka.ChangedResource;
 import uk.gov.companieshouse.api.chskafka.ChangedResourceEvent;
-import uk.gov.companieshouse.disqualifiedofficersdataapi.model.CorporateDisqualificationDocument;
+import uk.gov.companieshouse.api.disqualification.CorporateDisqualificationApi;
+import uk.gov.companieshouse.api.disqualification.NaturalDisqualificationApi;
 import uk.gov.companieshouse.disqualifiedofficersdataapi.model.DisqualificationResourceType;
-import uk.gov.companieshouse.disqualifiedofficersdataapi.model.NaturalDisqualificationDocument;
 
 @ExtendWith(MockitoExtension.class)
 public class ResourceChangedRequestMapperTest {
@@ -50,22 +50,6 @@ public class ResourceChangedRequestMapperTest {
     }
 
     @Test
-    void testMapperCorpDelete() {
-        ResourceChangedTestArgument argument = corporateResourceDeletedScenarios();
-        when(timestampGenerator.get()).thenReturn(DATE);
-        ChangedResource actual = mapper.mapChangedResource(argument.getRequest(), new CorporateDisqualificationDocument());
-        assertEquals(argument.getChangedResource(), actual);
-    }
-
-    @Test
-    void testMapperNatDelete() {
-        ResourceChangedTestArgument argument = naturalResourceDeletedScenarios();
-        when(timestampGenerator.get()).thenReturn(DATE);
-        ChangedResource actual = mapper.mapChangedResource(argument.getRequest(), new NaturalDisqualificationDocument());
-        assertEquals(argument.getChangedResource(), actual);
-    }
-
-    @Test
     void testMapperThrowsIllegalStateExceptionIfResourceTypeNull() {
         // when
         Executable executable = () -> mapper.mapChangedResource(request);
@@ -78,7 +62,7 @@ public class ResourceChangedRequestMapperTest {
     static Stream<ResourceChangedTestArgument> resourceChangedScenarios() {
         return Stream.of(
                 ResourceChangedTestArgument.builder()
-                        .withRequest(new ResourceChangedRequest(EXPECTED_CONTEXT_ID, "CH4000056", DisqualificationResourceType.NATURAL))
+                        .withRequest(new ResourceChangedRequest(EXPECTED_CONTEXT_ID, "CH4000056", DisqualificationResourceType.NATURAL, null))
                         .withContextId(EXPECTED_CONTEXT_ID)
                         .withResourceUri("/disqualified-officers/natural/CH4000056")
                         .withResourceKind("disqualified-officer-natural")
@@ -86,39 +70,32 @@ public class ResourceChangedRequestMapperTest {
                         .withEventPublishedAt(DATE)
                         .build(),
                 ResourceChangedTestArgument.builder()
-                        .withRequest(new ResourceChangedRequest(EXPECTED_CONTEXT_ID, "CH4000056", DisqualificationResourceType.CORPORATE))
+                        .withRequest(new ResourceChangedRequest(EXPECTED_CONTEXT_ID, "CH4000056", DisqualificationResourceType.CORPORATE, null))
                         .withContextId(EXPECTED_CONTEXT_ID)
                         .withResourceUri("/disqualified-officers/corporate/CH4000056")
                         .withResourceKind("disqualified-officer-corporate")
                         .withEventType("changed")
                         .withEventPublishedAt(DATE)
+                        .build(),
+                ResourceChangedTestArgument.builder()
+                        .withRequest(new ResourceChangedRequest(EXPECTED_CONTEXT_ID, "CH4000056", DisqualificationResourceType.CORPORATE, new CorporateDisqualificationApi()))
+                        .withContextId(EXPECTED_CONTEXT_ID)
+                        .withResourceUri("/disqualified-officers/corporate/CH4000056")
+                        .withResourceKind("disqualified-officer-corporate")
+                        .withEventType("deleted")
+                        .withEventPublishedAt(DATE)
+                        .withDeletedData(new CorporateDisqualificationApi())
+                        .build(),
+                ResourceChangedTestArgument.builder()
+                        .withRequest(new ResourceChangedRequest(EXPECTED_CONTEXT_ID, "CH4000056", DisqualificationResourceType.NATURAL, new NaturalDisqualificationApi()))
+                        .withContextId(EXPECTED_CONTEXT_ID)
+                        .withResourceUri("/disqualified-officers/natural/CH4000056")
+                        .withResourceKind("disqualified-officer-natural")
+                        .withEventType("deleted")
+                        .withEventPublishedAt(DATE)
+                        .withDeletedData(new NaturalDisqualificationApi())
                         .build()
         );
-    }
-
-    static ResourceChangedTestArgument corporateResourceDeletedScenarios() {
-        return ResourceChangedTestArgument.builder()
-            .withRequest(new ResourceChangedRequest(EXPECTED_CONTEXT_ID, "CH4000056", DisqualificationResourceType.CORPORATE))
-            .withContextId(EXPECTED_CONTEXT_ID)
-            .withResourceUri("/disqualified-officers/corporate/CH4000056")
-            .withResourceKind("disqualified-officer-corporate")
-            .withEventType("deleted")
-            .withEventPublishedAt(DATE)
-            .withDeletedData(new CorporateDisqualificationDocument().getData())
-            .build();
-    }
-
-
-    static ResourceChangedTestArgument naturalResourceDeletedScenarios() {
-        return ResourceChangedTestArgument.builder()
-            .withRequest(new ResourceChangedRequest(EXPECTED_CONTEXT_ID, "CH4000056", DisqualificationResourceType.NATURAL))
-            .withContextId(EXPECTED_CONTEXT_ID)
-            .withResourceUri("/disqualified-officers/natural/CH4000056")
-            .withResourceKind("disqualified-officer-natural")
-            .withEventType("deleted")
-            .withEventPublishedAt(DATE)
-            .withDeletedData(new NaturalDisqualificationDocument().getData())
-            .build();
     }
 
     static class ResourceChangedTestArgument {

--- a/src/test/java/uk/gov/companieshouse/disqualifiedofficersdataapi/api/controller/DisqualifiedOfficerControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/disqualifiedofficersdataapi/api/controller/DisqualifiedOfficerControllerTest.java
@@ -32,6 +32,7 @@ import static org.mockito.ArgumentMatchers.isA;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doThrow;
 import static org.springframework.http.MediaType.APPLICATION_JSON;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -41,7 +42,9 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 class DisqualifiedOfficerControllerTest {
     private static final String OFFICER_ID = "02588581";
     private static final String NATURAL = "natural";
+    private static final String DELETE = "delete";
     private static final String NATURAL_URL = String.format("/disqualified-officers/%s/%s/internal", NATURAL, OFFICER_ID);
+    private static final String DELETE_URL = String.format("/disqualified-officers/%s/%s/internal", DELETE, OFFICER_ID);
 
     @Autowired
     private MockMvc mockMvc;
@@ -166,6 +169,32 @@ class DisqualifiedOfficerControllerTest {
                         .contentType(APPLICATION_JSON)
                         .header("x-request-id", "5342342")
                         .content(gson.toJson(request)))
+                .andExpect(status().isServiceUnavailable());
+    }
+
+    @Test
+    @DisplayName("Disqualified Officer DELETE request")
+    public void callDisqualifiedOfficerDeleteRequest() throws Exception {
+
+        doNothing()
+                .when(disqualifiedOfficerService).deleteDisqualification(anyString(), anyString());
+
+        mockMvc.perform(delete(DELETE_URL)
+                        .contentType(APPLICATION_JSON)
+                        .header("x-request-id", "5342342"))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    @DisplayName("Disqualified Officer DELETE request - ServiceUnavailable status code 503")
+    public void callDisqualifiedOfficerDeleteRequestServiceUnavailable() throws Exception {
+
+        doThrow(new ServiceUnavailableException("Service Unavailable - connection issues"))
+                .when(disqualifiedOfficerService).deleteDisqualification(anyString(), anyString());
+
+        mockMvc.perform(delete(DELETE_URL)
+                        .contentType(APPLICATION_JSON)
+                        .header("x-request-id", "5342342"))
                 .andExpect(status().isServiceUnavailable());
     }
 }

--- a/src/test/java/uk/gov/companieshouse/disqualifiedofficersdataapi/service/DisqualifiedOfficerServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/disqualifiedofficersdataapi/service/DisqualifiedOfficerServiceTest.java
@@ -90,7 +90,7 @@ public class DisqualifiedOfficerServiceTest {
 
         verify(repository).save(document);
         verify(disqualifiedOfficerApiService).invokeChsKafkaApi(new ResourceChangedRequest("", "officerId",
-                DisqualificationResourceType.NATURAL));
+                DisqualificationResourceType.NATURAL, null));
         assertEquals(dateString, dateCaptor.getValue());
         assertNotNull(document.getCreated().getAt());
     }
@@ -106,7 +106,7 @@ public class DisqualifiedOfficerServiceTest {
 
         verify(repository).save(document);
         verify(disqualifiedOfficerApiService).invokeChsKafkaApi(new ResourceChangedRequest("", "officerId",
-                DisqualificationResourceType.NATURAL));
+                DisqualificationResourceType.NATURAL, null));
         assertEquals(dateString, dateCaptor.getValue());
         assertNotNull(document.getCreated());
     }
@@ -122,7 +122,7 @@ public class DisqualifiedOfficerServiceTest {
 
         verify(repository, times(0)).save(document);
         verify(disqualifiedOfficerApiService, times(0)).invokeChsKafkaApi(new ResourceChangedRequest("", "officerId",
-                DisqualificationResourceType.NATURAL));
+                DisqualificationResourceType.NATURAL, null));
         assertEquals(dateString, dateCaptor.getValue());
     }
 
@@ -136,7 +136,7 @@ public class DisqualifiedOfficerServiceTest {
 
         verify(repository).save(document);
         verify(disqualifiedOfficerApiService).invokeChsKafkaApi(new ResourceChangedRequest("", "officerId",
-                DisqualificationResourceType.CORPORATE));
+                DisqualificationResourceType.CORPORATE, null));
         assertEquals(dateString, dateCaptor.getValue());
         assertNotNull(document.getCreated().getAt());
     }
@@ -215,7 +215,7 @@ public class DisqualifiedOfficerServiceTest {
 
         verify(repository).delete(doc);
         verify(disqualifiedOfficerApiService).invokeChsKafkaApi(new ResourceChangedRequest("", "officerId",
-                DisqualificationResourceType.NATURAL), doc);
+                DisqualificationResourceType.NATURAL, doc.getData()));
     }
 
     @Test
@@ -230,7 +230,7 @@ public class DisqualifiedOfficerServiceTest {
 
         verify(repository).delete(doc);
         verify(disqualifiedOfficerApiService).invokeChsKafkaApi(new ResourceChangedRequest("", "officerId",
-                DisqualificationResourceType.CORPORATE), doc);
+                DisqualificationResourceType.CORPORATE, doc.getData()));
     }
 
     @Test

--- a/src/test/java/uk/gov/companieshouse/disqualifiedofficersdataapi/service/DisqualifiedOfficerServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/disqualifiedofficersdataapi/service/DisqualifiedOfficerServiceTest.java
@@ -90,7 +90,7 @@ public class DisqualifiedOfficerServiceTest {
 
         verify(repository).save(document);
         verify(disqualifiedOfficerApiService).invokeChsKafkaApi(new ResourceChangedRequest("", "officerId",
-                DisqualificationResourceType.NATURAL, null));
+                DisqualificationResourceType.NATURAL, null, false));
         assertEquals(dateString, dateCaptor.getValue());
         assertNotNull(document.getCreated().getAt());
     }
@@ -106,7 +106,7 @@ public class DisqualifiedOfficerServiceTest {
 
         verify(repository).save(document);
         verify(disqualifiedOfficerApiService).invokeChsKafkaApi(new ResourceChangedRequest("", "officerId",
-                DisqualificationResourceType.NATURAL, null));
+                DisqualificationResourceType.NATURAL, null, false));
         assertEquals(dateString, dateCaptor.getValue());
         assertNotNull(document.getCreated());
     }
@@ -122,7 +122,7 @@ public class DisqualifiedOfficerServiceTest {
 
         verify(repository, times(0)).save(document);
         verify(disqualifiedOfficerApiService, times(0)).invokeChsKafkaApi(new ResourceChangedRequest("", "officerId",
-                DisqualificationResourceType.NATURAL, null));
+                DisqualificationResourceType.NATURAL, null, false));
         assertEquals(dateString, dateCaptor.getValue());
     }
 
@@ -136,7 +136,7 @@ public class DisqualifiedOfficerServiceTest {
 
         verify(repository).save(document);
         verify(disqualifiedOfficerApiService).invokeChsKafkaApi(new ResourceChangedRequest("", "officerId",
-                DisqualificationResourceType.CORPORATE, null));
+                DisqualificationResourceType.CORPORATE, null, false));
         assertEquals(dateString, dateCaptor.getValue());
         assertNotNull(document.getCreated().getAt());
     }
@@ -215,7 +215,7 @@ public class DisqualifiedOfficerServiceTest {
 
         verify(repository).delete(doc);
         verify(disqualifiedOfficerApiService).invokeChsKafkaApi(new ResourceChangedRequest("", "officerId",
-                DisqualificationResourceType.NATURAL, doc.getData()));
+                DisqualificationResourceType.NATURAL, doc.getData(), true));
     }
 
     @Test
@@ -230,7 +230,7 @@ public class DisqualifiedOfficerServiceTest {
 
         verify(repository).delete(doc);
         verify(disqualifiedOfficerApiService).invokeChsKafkaApi(new ResourceChangedRequest("", "officerId",
-                DisqualificationResourceType.CORPORATE, doc.getData()));
+                DisqualificationResourceType.CORPORATE, doc.getData(), true));
     }
 
     @Test


### PR DESCRIPTION
This PR adds a delete endpoint to the data api allowing the record to be found and then call chs-kafka-api with either a corporate or natural object depending on the type found by id:

**Resolves**
DSND-813