### PR TITLE
Add resolver for pre 1970 dates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,6 @@ hs_err_pid*
 
 #Intellij
 .idea
+
+# VS Code
+settings.json

--- a/src/itest/java/uk/gov/companieshouse/disqualifiedofficersdataapi/steps/NaturalDisqualificationSteps.java
+++ b/src/itest/java/uk/gov/companieshouse/disqualifiedofficersdataapi/steps/NaturalDisqualificationSteps.java
@@ -29,7 +29,6 @@ import static uk.gov.companieshouse.disqualifiedofficersdataapi.config.AbstractM
 
 public class NaturalDisqualificationSteps {
 
-    private String officerId;
     private String contextId;
 
     @Autowired
@@ -97,13 +96,12 @@ public class NaturalDisqualificationSteps {
         CucumberContext.CONTEXT.set("contextId", this.contextId);
         headers.set("x-request-id", this.contextId);
 
-        HttpEntity request = new HttpEntity(data, headers);
+        HttpEntity<String> request = new HttpEntity<String>(data, headers);
         String uri = "/disqualified-officers/natural/{officerId}/internal";
         CucumberContext.CONTEXT.set("officerType", DisqualificationResourceType.NATURAL);
         String officerId = "1234567890";
         ResponseEntity<Void> response = restTemplate.exchange(uri, HttpMethod.PUT, request, Void.class, officerId);
 
-        this.officerId = officerId;
         CucumberContext.CONTEXT.set("statusCode", response.getStatusCodeValue());
     }
 
@@ -116,6 +114,7 @@ public class NaturalDisqualificationSteps {
 
         assertThat(expected.getSurname()).isEqualTo(actual.getSurname());
         assertThat(expected.getDisqualifications()).isEqualTo(actual.getDisqualifications());
+        assertThat(expected.getDateOfBirth()).isEqualTo(actual.getDateOfBirth());
     }
 
     @After

--- a/src/itest/resources/json/output/retrieve_natural_disqualified_officer.json
+++ b/src/itest/resources/json/output/retrieve_natural_disqualified_officer.json
@@ -1,5 +1,5 @@
 {
-  "date_of_birth": "1976-02-06",
+  "date_of_birth": "1953-02-06",
   "person_number": null,
   "etag": "bd61fa22f9cacbf959334535069164f83e1fc2a0",
   "forename": "Dust",

--- a/src/main/java/uk/gov/companieshouse/disqualifiedofficersdataapi/serialization/LocalDateDeSerializer.java
+++ b/src/main/java/uk/gov/companieshouse/disqualifiedofficersdataapi/serialization/LocalDateDeSerializer.java
@@ -8,7 +8,9 @@ import uk.gov.companieshouse.disqualifiedofficersdataapi.exceptions.BadRequestEx
 import uk.gov.companieshouse.logging.Logger;
 import uk.gov.companieshouse.logging.LoggerFactory;
 
+import java.time.Instant;
 import java.time.LocalDate;
+import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 
 public class LocalDateDeSerializer extends JsonDeserializer<LocalDate> {
@@ -23,7 +25,10 @@ public class LocalDateDeSerializer extends JsonDeserializer<LocalDate> {
             DateTimeFormatter dateTimeFormatter = DateTimeFormatter
                     .ofPattern("yyyy-MM-dd'T'HH:mm:ss'Z'");
             JsonNode jsonNode = jsonParser.readValueAsTree();
-            return LocalDate.parse(jsonNode.get("$date").textValue(), dateTimeFormatter);
+            JsonNode dateNode = jsonNode.get("$date");
+            return dateNode.textValue() != null ? 
+                    LocalDate.parse(dateNode.textValue(), dateTimeFormatter) :
+                    LocalDate.ofInstant(Instant.ofEpochMilli(dateNode.get("$numberLong").asLong()), ZoneId.systemDefault());
         } catch (Exception exception) {
             LOGGER.error("Deserialization failed.", exception);
             throw new BadRequestException(exception.getMessage());


### PR DESCRIPTION
Allow both pre and post 1970 dates to be correctly deserialised to LocalDate values from the mongo record:

**Resolves**
DSND-1064

Separate - add vscode settings to .gitignore