### PR TITLE
Add delete integration testing for disqualification

### DIFF
--- a/src/itest/java/uk/gov/companieshouse/disqualifiedofficersdataapi/steps/DisqualificationSteps.java
+++ b/src/itest/java/uk/gov/companieshouse/disqualifiedofficersdataapi/steps/DisqualificationSteps.java
@@ -83,7 +83,7 @@ public class DisqualificationSteps {
         verify(disqualifiedApiService, times(0)).invokeChsKafkaApi(any(ResourceChangedRequest.class));
     }
 
-    @Then("the CHS Kafka API is invoked successfully with {string}")
+    @Then("the CHS Kafka API is invoked with {string}")
     public void chs_kafka_api_invoked(String officerId) {
         boolean isDelete = officerId.equals("id_to_delete") ? true : false;
 
@@ -107,7 +107,7 @@ public class DisqualificationSteps {
         int expectedStatusCode = CucumberContext.CONTEXT.get("statusCode");
         Assertions.assertThat(expectedStatusCode).isEqualTo(statusCode);
     }
-    
+
     @Then("the disqualified officer with officer id {string} still exists in the database")
     public void disqualified_officer_exists(String officerId) {
         Assertions.assertThat(repository.existsById(officerId));

--- a/src/itest/java/uk/gov/companieshouse/disqualifiedofficersdataapi/steps/DisqualificationSteps.java
+++ b/src/itest/java/uk/gov/companieshouse/disqualifiedofficersdataapi/steps/DisqualificationSteps.java
@@ -3,18 +3,22 @@ package uk.gov.companieshouse.disqualifiedofficersdataapi.steps;
 import java.io.IOException;
 import java.util.List;
 
-import com.github.dockerjava.api.exception.InternalServerErrorException;
 import io.cucumber.java.en.Given;
 import io.cucumber.java.en.Then;
 import io.cucumber.java.en.When;
 import org.assertj.core.api.Assertions;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
 import uk.gov.companieshouse.disqualifiedofficersdataapi.api.DisqualifiedOfficerApiService;
 import uk.gov.companieshouse.disqualifiedofficersdataapi.api.ResourceChangedRequest;
 import uk.gov.companieshouse.disqualifiedofficersdataapi.config.CucumberContext;
 import uk.gov.companieshouse.disqualifiedofficersdataapi.exceptions.ServiceUnavailableException;
 import uk.gov.companieshouse.disqualifiedofficersdataapi.model.DisqualificationDocument;
+import uk.gov.companieshouse.disqualifiedofficersdataapi.model.DisqualificationResourceType;
 import uk.gov.companieshouse.disqualifiedofficersdataapi.repository.DisqualifiedOfficerRepository;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -24,6 +28,8 @@ import static org.mockito.Mockito.*;
 import static uk.gov.companieshouse.disqualifiedofficersdataapi.config.AbstractMongoConfig.mongoDBContainer;
 
 public class DisqualificationSteps {
+
+    private String officerId;
 
     @Autowired
     public DisqualifiedOfficerApiService disqualifiedApiService;
@@ -50,10 +56,26 @@ public class DisqualificationSteps {
             .when(disqualifiedApiService).invokeChsKafkaApi(any(ResourceChangedRequest.class));
     }
 
-    @When("the api throws an internal server error")
-    public void api_throws_an_internal_service_error() throws IOException {
-        doThrow(InternalServerErrorException.class)
-            .when(disqualifiedApiService).invokeChsKafkaApi(any(ResourceChangedRequest.class));
+    @When("I send DELETE request with officer id {string}")
+    public void send_delete_request_for_officer(String officerId) throws IOException {
+        String uri = "/disqualified-officers/delete/{officer_id}/internal";
+
+        HttpHeaders headers = new HttpHeaders();
+        CucumberContext.CONTEXT.set("contextId", "5234234234");
+        this.officerId = officerId;
+        CucumberContext.CONTEXT.set("officerType", DisqualificationResourceType.NATURAL);
+        headers.set("x-request-id", CucumberContext.CONTEXT.get("contextId"));
+
+        HttpEntity<String> request = new HttpEntity<String>(null, headers);
+
+        ResponseEntity<Void> response = restTemplate.exchange(uri, HttpMethod.DELETE, request, Void.class, officerId);
+
+        CucumberContext.CONTEXT.set("statusCode", response.getStatusCodeValue());
+    }
+
+    @When("officer id does not exists for {string}")
+    public void officer_does_not_exists(String officerId) {
+        Assertions.assertThat(repository.existsById(officerId)).isFalse();
     }
 
     @Then("the CHS Kafka API is not invoked")
@@ -63,12 +85,14 @@ public class DisqualificationSteps {
 
     @Then("the CHS Kafka API is invoked successfully with {string}")
     public void chs_kafka_api_invoked(String officerId) {
+        boolean isDelete = officerId.equals("id_to_delete") ? true : false;
+
         verify(disqualifiedApiService).invokeChsKafkaApi(new ResourceChangedRequest(
             CucumberContext.CONTEXT.get("contextId"),
             officerId,
             CucumberContext.CONTEXT.get("officerType"),
-            null,
-            false
+            isDelete ? CucumberContext.CONTEXT.get("disqualificationData") : null,
+            isDelete
         ));
     }
 
@@ -82,6 +106,11 @@ public class DisqualificationSteps {
     public void i_should_receive_status_code(Integer statusCode) {
         int expectedStatusCode = CucumberContext.CONTEXT.get("statusCode");
         Assertions.assertThat(expectedStatusCode).isEqualTo(statusCode);
+    }
+    
+    @Then("the disqualified officer with officer id {string} still exists in the database")
+    public void disqualified_officer_exists(String officerId) {
+        Assertions.assertThat(repository.existsById(officerId));
     }
 
 }

--- a/src/itest/java/uk/gov/companieshouse/disqualifiedofficersdataapi/steps/NaturalDisqualificationSteps.java
+++ b/src/itest/java/uk/gov/companieshouse/disqualifiedofficersdataapi/steps/NaturalDisqualificationSteps.java
@@ -3,6 +3,7 @@ package uk.gov.companieshouse.disqualifiedofficersdataapi.steps;
 import java.io.File;
 import java.io.IOException;
 import java.util.Collections;
+
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.cucumber.java.After;
 import io.cucumber.java.Before;

--- a/src/itest/java/uk/gov/companieshouse/disqualifiedofficersdataapi/steps/NaturalDisqualificationSteps.java
+++ b/src/itest/java/uk/gov/companieshouse/disqualifiedofficersdataapi/steps/NaturalDisqualificationSteps.java
@@ -9,6 +9,7 @@ import io.cucumber.java.Before;
 import io.cucumber.java.en.Given;
 import io.cucumber.java.en.Then;
 import io.cucumber.java.en.When;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.web.client.TestRestTemplate;
 import org.springframework.core.io.ClassPathResource;
@@ -71,6 +72,7 @@ public class NaturalDisqualificationSteps {
         naturalDisqualification.setId(officerId);
 
         mongoTemplate.save(naturalDisqualification);
+        CucumberContext.CONTEXT.set("disqualificationData", natData);
     }
 
     @When("I send natural GET request with officer Id {string}")

--- a/src/itest/resources/features/corporate_disqualification.feature
+++ b/src/itest/resources/features/corporate_disqualification.feature
@@ -5,7 +5,7 @@ Feature: Process corporate disqualified officer information
     Given disqualified officers data api service is running
     When I send corporate PUT request with payload "<data>" file
     Then I should receive 200 status code
-    And the CHS Kafka API is invoked successfully with "<officerId>"
+    And the CHS Kafka API is invoked with "<officerId>"
 
     Examples:
       | data                                  | officerId     |

--- a/src/itest/resources/features/natural_disqualification.feature
+++ b/src/itest/resources/features/natural_disqualification.feature
@@ -5,7 +5,7 @@ Feature: Process natural disqualified officer information
     Given disqualified officers data api service is running
     When I send natural PUT request with payload "<data>" file
     Then I should receive 200 status code
-    And the CHS Kafka API is invoked successfully with "<officerId>"
+    And the CHS Kafka API is invoked with "<officerId>"
 
     Examples:
       | data                                  | officerId     |

--- a/src/itest/resources/features/officer_disq_status_response_codes.feature
+++ b/src/itest/resources/features/officer_disq_status_response_codes.feature
@@ -24,11 +24,13 @@ Scenario: Processing disqualified officers information unsuccessfully after inte
     When CHS kafka API service is unavailable
     And I send natural PUT request with payload "<data>" file
     Then I should receive 503 status code
-    And the CHS Kafka API is invoked successfully with "<officerId>"
+    And I send natural GET request with officer Id "<officerId>"
+    And the natural Get call response body should match "<result>" file
+    And the CHS Kafka API is invoked with "<officerId>"
 
     Examples:
-        | data                         | officerId  |
-        | natural_disqualified_officer | 1234567890 |
+        | data                         | officerId  | result                                |
+        | natural_disqualified_officer | 1234567890 | retrieve_natural_disqualified_officer |
 
   Scenario: Processing disqualified officers information while database is down
 

--- a/src/itest/resources/features/officer_disq_status_response_codes.feature
+++ b/src/itest/resources/features/officer_disq_status_response_codes.feature
@@ -12,11 +12,10 @@ Feature: Response codes scenarios for disqualification officer
         | data                | response_code |
         | bad_request_natural | 400           |
 
-  Scenario: Processing disqualified officers information unsuccessfully after internal server error
+Scenario: Processing disqualified officers information unsuccessfully after internal server error
 
     Given disqualified officers data api service is running
-    When the api throws an internal server error
-    And I send natural PUT request with payload "natural_disqualified_officer" file
+    When I send natural PUT request with payload "internal_server_error_request" file
     Then I should receive 500 status code
 
   Scenario Outline: Processing disqualified officers information unsuccessfully but saves to database
@@ -25,12 +24,11 @@ Feature: Response codes scenarios for disqualification officer
     When CHS kafka API service is unavailable
     And I send natural PUT request with payload "<data>" file
     Then I should receive 503 status code
-    And the natural Get call response body should match "<result>" file
     And the CHS Kafka API is invoked successfully with "<officerId>"
 
     Examples:
-        | data                         | result                                | officerId  |
-        | natural_disqualified_officer | retrieve_natural_disqualified_officer | 1234567890 |
+        | data                         | officerId  |
+        | natural_disqualified_officer | 1234567890 |
 
   Scenario: Processing disqualified officers information while database is down
 

--- a/src/itest/resources/features/officer_disqualification_delete.feature
+++ b/src/itest/resources/features/officer_disqualification_delete.feature
@@ -6,7 +6,7 @@ Feature: Delete disqualification information
     And the natural disqualified officer information exists for "id_to_delete"
     When I send DELETE request with officer id "id_to_delete"
     Then I should receive 200 status code
-    And the CHS Kafka API is invoked successfully with "id_to_delete"
+    And the CHS Kafka API is invoked with "id_to_delete"
 
   Scenario: Delete disqualified officer information while database is down
 
@@ -25,13 +25,12 @@ Feature: Delete disqualification information
     Then I should receive 404 status code
     And the CHS Kafka API is not invoked
 
-  Scenario: Processing delete disqualified officer when kafka-api is not available
+  Scenario: Delete disqualified officer when kafka-api is not available
 
     Given disqualified officers data api service is running
     And the natural disqualified officer information exists for "id_to_delete"
     And CHS kafka API service is unavailable
     When I send DELETE request with officer id "id_to_delete"
     Then I should receive 503 status code
-    And the CHS Kafka API is invoked successfully with "id_to_delete"
-    And the disqualified officer with officer id "id_to_delete" still exists in the database
+    And officer id does not exists for "id_to_delete"
 

--- a/src/itest/resources/features/officer_disqualification_delete.feature
+++ b/src/itest/resources/features/officer_disqualification_delete.feature
@@ -1,0 +1,37 @@
+Feature: Delete disqualification information
+
+  Scenario: Delete disqualified officer successfully
+
+    Given disqualified officers data api service is running
+    And the natural disqualified officer information exists for "id_to_delete"
+    When I send DELETE request with officer id "id_to_delete"
+    Then I should receive 200 status code
+    And the CHS Kafka API is invoked successfully with "id_to_delete"
+
+  Scenario: Delete disqualified officer information while database is down
+
+    Given disqualified officers data api service is running
+    And the natural disqualified officer information exists for "1234567890"
+    And the disqualification database is down
+    When I send DELETE request with officer id "1234567891"
+    Then I should receive 503 status code
+    And the CHS Kafka API is not invoked
+
+  Scenario: Delete disqualified officer information not found
+
+    Given disqualified officers data api service is running
+    When I send DELETE request with officer id "does_not_exist"
+    And officer id does not exists for "does_not_exist"
+    Then I should receive 404 status code
+    And the CHS Kafka API is not invoked
+
+  Scenario: Processing delete disqualified officer when kafka-api is not available
+
+    Given disqualified officers data api service is running
+    And the natural disqualified officer information exists for "id_to_delete"
+    And CHS kafka API service is unavailable
+    When I send DELETE request with officer id "id_to_delete"
+    Then I should receive 503 status code
+    And the CHS Kafka API is invoked successfully with "id_to_delete"
+    And the disqualified officer with officer id "id_to_delete" still exists in the database
+

--- a/src/itest/resources/json/input/internal_server_error_request.json
+++ b/src/itest/resources/json/input/internal_server_error_request.json
@@ -1,0 +1,25 @@
+{
+    "external_data" : {
+      "person_number" : "2",
+      "date_of_birth" : "2022-04-05T12:51:00.767Z",
+      "etag" : "",
+      "title": "Mr",
+      "forename": "Dust",
+      "middle_name": "Condition Reserve",
+      "surname": "KINDNESSLIQUOR",
+      "honours": "",
+      "nationality": "British",
+      "registered_location": "Britain",
+      "disqualifications" : [],
+      "links" : {
+        "self" : "link"
+      }
+    },
+    "internal_data" : {
+      "delta_at" : null,
+      "officer_id" : "1234567890",
+      "officer_id_raw" : "1234567890",
+      "officer_disq_id" : "1234567890",
+      "officer_detail_id" : "1234567890"
+    }
+  }

--- a/src/itest/resources/json/input/natural_disqualified_officer.json
+++ b/src/itest/resources/json/input/natural_disqualified_officer.json
@@ -1,53 +1,53 @@
 {
-  "external_data" : {
-    "person_number" : "2",
-    "date_of_birth" : "2022-04-05T12:51:00.767Z",
-    "etag" : "",
-    "title": "Mr",
-    "forename": "Dust",
-    "middle_name": "Condition Reserve",
-    "surname": "KINDNESSLIQUOR",
-    "honours": "",
-    "nationality": "British",
-    "registered_location": "Britain",
-    "disqualifications" : [
-      {
-        "address": {
-          "premise": "30",
-          "address_line_1": "Lucy Road",
-          "address_line_2": "Skewen",
-          "locality": "Neath",
-          "region": "",
-          "country": "Wales",
-          "postal_code": "SA10 6RR"
-        },
-        "case_identifier" : "INV3975227",
-        "company_names": [
-          "CONSORTIUM TECHNOLOGY LIMITED"
-        ],
-        "court_name" : "Insolvency Service",
-        "disqualification_type" : "UNDERTAKING",
-        "disqualified_from" : "2022-04-05T12:51:00.767Z",
-        "disqualified_until" : "2022-04-05T12:51:00.767Z",
-        "heard_on" : "2022-04-05T12:51:00.767Z",
-        "undertaken_on" : "2022-04-05T12:51:00.767Z",
-        "reason" : {
-          "description_identifier" : "string",
-          "section" : "CDDA 1987",
-          "act" : "7",
-          "article" : "string"
+    "external_data" : {
+      "person_number" : "2",
+      "date_of_birth" : "2022-04-05T12:51:00.767Z",
+      "etag" : "",
+      "title": "Mr",
+      "forename": "Dust",
+      "middle_name": "Condition Reserve",
+      "surname": "KINDNESSLIQUOR",
+      "honours": "",
+      "nationality": "British",
+      "registered_location": "Britain",
+      "disqualifications" : [
+        {
+          "address": {
+            "premise": "30",
+            "address_line_1": "Lucy Road",
+            "address_line_2": "Skewen",
+            "locality": "Neath",
+            "region": "",
+            "country": "Wales",
+            "postal_code": "SA10 6RR"
+          },
+          "case_identifier" : "INV3975227",
+          "company_names": [
+            "CONSORTIUM TECHNOLOGY LIMITED"
+          ],
+          "court_name" : "Insolvency Service",
+          "disqualification_type" : "UNDERTAKING",
+          "disqualified_from" : "2022-04-05T12:51:00.767Z",
+          "disqualified_until" : "2022-04-05T12:51:00.767Z",
+          "heard_on" : "2022-04-05T12:51:00.767Z",
+          "undertaken_on" : "2022-04-05T12:51:00.767Z",
+          "reason" : {
+            "description_identifier" : "string",
+            "section" : "CDDA 1987",
+            "act" : "7",
+            "article" : "string"
+          }
         }
+      ],
+      "links" : {
+        "self" : "link"
       }
-    ],
-    "links" : {
-      "self" : "link"
+    },
+    "internal_data" : {
+      "delta_at" : "2030-04-05T15:51:00.768Z",
+      "officer_id" : "1234567890",
+      "officer_id_raw" : "1234567890",
+      "officer_disq_id" : "1234567890",
+      "officer_detail_id" : "1234567890"
     }
-  },
-  "internal_data" : {
-    "delta_at" : "2022-04-05T15:51:00.768Z",
-    "officer_id" : "1234567890",
-    "officer_id_raw" : "1234567890",
-    "officer_disq_id" : "1234567890",
-    "officer_detail_id" : "1234567890"
   }
-}

--- a/src/itest/resources/json/output/retrieve_natural_disqualified_officer.json
+++ b/src/itest/resources/json/output/retrieve_natural_disqualified_officer.json
@@ -1,59 +1,45 @@
 {
-  "date_of_birth": "1953-02-06",
-  "person_number": null,
-  "etag": "bd61fa22f9cacbf959334535069164f83e1fc2a0",
-  "forename": "Dust",
-  "honours": "",
-  "nationality": "British",
-  "other_forenames": "Condition Reserve",
-  "surname": "KINDNESSLIQUOR",
-  "title": "Mr",
-  "links": {
-    "self": "/disqualified-officers/natural/nRr-8Teoxjl5d7hwovzpJl7mYJ0"
-  },
-  "disqualifications": [
-    {
-      "case_identifier": "INV3975227",
-      "address": {
-        "premise": "30",
-        "address_line_1": "Lucy Road",
-        "address_line_2": "Skewen",
-        "locality": "Neath",
-        "region": "",
-        "country": "Wales",
-        "postal_code": "SA10 6RR"
-      },
-      "company_names": [
-        "CONSORTIUM TECHNOLOGY LIMITED"
-      ],
-      "court_name": null,
-      "disqualification_type": "undertaking",
-      "disqualified_from": "2015-02-18",
-      "disqualified_until": "2025-02-17",
-      "heard_on": null,
-      "undertaken_on": "2015-02-14",
-      "last_variation": {
-        "varied_on": "2021-02-17",
-        "case_identifier": "1",
-        "court_name": "Judys"
-      },
-      "reason": {
-        "act": "company-directors-disqualification-act-1986",
-        "section": "7",
-        "description_identifier": "order-or-undertaking-and-reporting-provisions"
-      }
-    }
-  ],
-  "permissions_to_act": [
-    {
-      "company_names": [
-        "123 LTD",
-        "321 LTD"
-      ],
-      "court_name": "rinder",
-      "expires_on": "2016-04-12",
-      "granted_on": "2014-02-03",
-      "purpose": null
-    }
-  ]
+    "date_of_birth": "2022-04-05",
+    "person_number": null,
+    "etag": "7a0ba73f960315629fa36fc41b4d325881773245",
+    "forename": "Dust",
+    "honours": "",
+    "nationality": "British",
+    "other_forenames": null,
+    "surname": "KINDNESSLIQUOR",
+    "title": "Mr",
+    "links": {
+        "self": "link"
+    },
+    "disqualifications": [
+        {
+            "case_identifier": "INV3975227",
+            "address": {
+                "premise": "30",
+                "address_line_1": "Lucy Road",
+                "address_line_2": "Skewen",
+                "locality": "Neath",
+                "region": "",
+                "country": "Wales",
+                "postal_code": "SA10 6RR"
+            },
+            "company_names": [
+                "CONSORTIUM TECHNOLOGY LIMITED"
+            ],
+            "court_name": "Insolvency Service",
+            "disqualification_type": "UNDERTAKING",
+            "disqualified_from": "2022-04-05",
+            "disqualified_until": "2022-04-05",
+            "heard_on": "2022-04-05",
+            "undertaken_on": "2022-04-05",
+            "last_variation": null,
+            "reason": {
+                "description_identifier": "string",
+                "section": "CDDA 1987",
+                "act": "7",
+                "article": "string"
+            }
+        }
+    ],
+    "permissions_to_act": null
 }

--- a/src/main/java/uk/gov/companieshouse/disqualifiedofficersdataapi/api/ResourceChangedRequest.java
+++ b/src/main/java/uk/gov/companieshouse/disqualifiedofficersdataapi/api/ResourceChangedRequest.java
@@ -42,17 +42,14 @@ public class ResourceChangedRequest {
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (o == null || getClass() != o.getClass()) {
-            return false;
-        }
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
         ResourceChangedRequest that = (ResourceChangedRequest) o;
-        return Objects.equals(contextId, that.contextId) && Objects.equals(
-                officerId, that.officerId) && type == that.type &&
-                disqualificationData == that.disqualificationData &&
-                isDelete == that.isDelete;
+        return Objects.equals(contextId, that.contextId) &&
+                Objects.equals(officerId, that.officerId) &&
+                type == that.type &&
+                Objects.equals(disqualificationData, that.disqualificationData) &&
+                Objects.equals(isDelete, that.isDelete);
     }
 
     @Override


### PR DESCRIPTION
This PR is to add integration testing to test the delete request for the disqualification API, this includes a fix for checking for a 500 internal error in the response code for the API.

- DSND-1040