### PR TITLE
Add eric authentication filter

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -109,6 +109,10 @@
             </exclusions>
         </dependency>
         <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-security</artifactId>
+        </dependency>
+        <dependency>
             <groupId>uk.gov.companieshouse</groupId>
             <artifactId>structured-logging</artifactId>
             <version>${structured-logging.version}</version>

--- a/src/itest/java/uk/gov/companieshouse/disqualifiedofficersdataapi/steps/CorporateDisqualificationSteps.java
+++ b/src/itest/java/uk/gov/companieshouse/disqualifiedofficersdataapi/steps/CorporateDisqualificationSteps.java
@@ -79,7 +79,13 @@ public class CorporateDisqualificationSteps {
     @When("I send corporate GET request with officer Id {string}")
     public void i_send_corporate_get_request_with_officer_id(String officerId) throws IOException {
         String uri = "/disqualified-officers/corporate/{officerId}";
-        ResponseEntity<CorporateDisqualificationApi> response = restTemplate.exchange(uri, HttpMethod.GET, null,
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.set("ERIC-Identity", "TEST-IDENTITY");
+        headers.set("ERIC-Identity-Type", "KEY");
+        HttpEntity<String> request = new HttpEntity<String>(null, headers);
+
+        ResponseEntity<CorporateDisqualificationApi> response = restTemplate.exchange(uri, HttpMethod.GET, request,
                 CorporateDisqualificationApi.class, officerId);
 
         CucumberContext.CONTEXT.set("statusCode", response.getStatusCodeValue());
@@ -98,6 +104,8 @@ public class CorporateDisqualificationSteps {
         this.contextId = "5234234234";
         CucumberContext.CONTEXT.set("contextId", this.contextId);
         headers.set("x-request-id", this.contextId);
+        headers.set("ERIC-Identity", "TEST-IDENTITY");
+        headers.set("ERIC-Identity-Type", "KEY");
 
         HttpEntity request = new HttpEntity(data, headers);
         String uri = "/disqualified-officers/corporate/{officerId}/internal";

--- a/src/itest/java/uk/gov/companieshouse/disqualifiedofficersdataapi/steps/DisqualificationSteps.java
+++ b/src/itest/java/uk/gov/companieshouse/disqualifiedofficersdataapi/steps/DisqualificationSteps.java
@@ -65,6 +65,8 @@ public class DisqualificationSteps {
         this.officerId = officerId;
         CucumberContext.CONTEXT.set("officerType", DisqualificationResourceType.NATURAL);
         headers.set("x-request-id", CucumberContext.CONTEXT.get("contextId"));
+        headers.set("ERIC-Identity", "TEST-IDENTITY");
+        headers.set("ERIC-Identity-Type", "KEY");
 
         HttpEntity<String> request = new HttpEntity<String>(null, headers);
 

--- a/src/itest/java/uk/gov/companieshouse/disqualifiedofficersdataapi/steps/NaturalDisqualificationSteps.java
+++ b/src/itest/java/uk/gov/companieshouse/disqualifiedofficersdataapi/steps/NaturalDisqualificationSteps.java
@@ -79,7 +79,13 @@ public class NaturalDisqualificationSteps {
     @When("I send natural GET request with officer Id {string}")
     public void i_send_natural_get_request_with_officer_id(String officerId) throws IOException {
         String uri = "/disqualified-officers/natural/{officerId}";
-        ResponseEntity<NaturalDisqualificationApi> response = restTemplate.exchange(uri, HttpMethod.GET, null,
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.set("ERIC-Identity", "TEST-IDENTITY");
+        headers.set("ERIC-Identity-Type", "KEY");
+        HttpEntity<String> request = new HttpEntity<String>(null, headers);
+
+        ResponseEntity<NaturalDisqualificationApi> response = restTemplate.exchange(uri, HttpMethod.GET, request,
                 NaturalDisqualificationApi.class, officerId);
 
         CucumberContext.CONTEXT.set("statusCode", response.getStatusCodeValue());
@@ -90,6 +96,29 @@ public class NaturalDisqualificationSteps {
     @When("I send natural PUT request with payload {string} file")
     public void i_send_natural_put_request_with_payload(String dataFile) throws IOException {
         String data = FileReaderUtil.readFile("src/itest/resources/json/input/" + dataFile + ".json");
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        headers.setAccept(Collections.singletonList(MediaType.APPLICATION_JSON));
+
+        this.contextId = "5234234234";
+        CucumberContext.CONTEXT.set("contextId", this.contextId);
+        headers.set("x-request-id", this.contextId);
+        headers.set("ERIC-Identity", "TEST-IDENTITY");
+        headers.set("ERIC-Identity-Type", "KEY");
+
+        HttpEntity<String> request = new HttpEntity<String>(data, headers);
+        String uri = "/disqualified-officers/natural/{officerId}/internal";
+        CucumberContext.CONTEXT.set("officerType", DisqualificationResourceType.NATURAL);
+        String officerId = "1234567890";
+        ResponseEntity<Void> response = restTemplate.exchange(uri, HttpMethod.PUT, request, Void.class, officerId);
+
+        CucumberContext.CONTEXT.set("statusCode", response.getStatusCodeValue());
+    }
+
+    @When("I send natural PUT request without ERIC headers")
+    public void i_send_natural_put_request_without_ERIC_headers() throws IOException {
+        String data = FileReaderUtil.readFile("src/itest/resources/json/input/natural_disqualified_officer.json");
 
         HttpHeaders headers = new HttpHeaders();
         headers.setContentType(MediaType.APPLICATION_JSON);

--- a/src/itest/resources/features/officer_disq_status_response_codes.feature
+++ b/src/itest/resources/features/officer_disq_status_response_codes.feature
@@ -39,3 +39,8 @@ Scenario: Processing disqualified officers information unsuccessfully after inte
     When I send natural PUT request with payload "natural_disqualified_officer" file
     Then I should receive 503 status code
     And the CHS Kafka API is not invoked
+
+  Scenario: Proccessing disqualified officers information without ERIC headers
+    Given disqualified officers data api service is running
+    When I send natural PUT request without ERIC headers
+    Then I should receive 403 status code

--- a/src/main/java/uk/gov/companieshouse/disqualifiedofficersdataapi/auth/EricTokenAuthenticationFilter.java
+++ b/src/main/java/uk/gov/companieshouse/disqualifiedofficersdataapi/auth/EricTokenAuthenticationFilter.java
@@ -1,0 +1,44 @@
+package uk.gov.companieshouse.disqualifiedofficersdataapi.auth;
+
+import java.io.IOException;
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.apache.commons.lang.StringUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+import uk.gov.companieshouse.logging.Logger;
+
+public class EricTokenAuthenticationFilter extends OncePerRequestFilter {
+
+    private final Logger logger;
+
+    public EricTokenAuthenticationFilter(Logger logger) {
+        this.logger = logger;
+    }
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
+                                    FilterChain filterChain) throws ServletException, IOException {
+
+        String ericIdentity = request.getHeader("ERIC-Identity");
+
+        if (StringUtils.isBlank(ericIdentity)) {
+            logger.error("Unauthorised request received without eric identity");
+            response.sendError(HttpServletResponse.SC_FORBIDDEN);
+            return;
+        }
+
+        String ericId = request.getHeader("ERIC-Identity-Type");
+
+        if (StringUtils.isBlank(ericId) ||
+                ! (ericId.equalsIgnoreCase("key") || ericId.equalsIgnoreCase("oauth2"))) {
+            logger.error("Unauthorised request received without eric identity type");
+            response.sendError(HttpServletResponse.SC_FORBIDDEN);
+            return;
+        }
+
+        filterChain.doFilter(request, response);
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/disqualifiedofficersdataapi/auth/EricTokenAuthenticationFilter.java
+++ b/src/main/java/uk/gov/companieshouse/disqualifiedofficersdataapi/auth/EricTokenAuthenticationFilter.java
@@ -22,18 +22,18 @@ public class EricTokenAuthenticationFilter extends OncePerRequestFilter {
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
                                     FilterChain filterChain) throws ServletException, IOException {
 
-        String ericIdentity = request.getHeader("ERIC-Identity");
+        String ericId = request.getHeader("ERIC-Identity");
 
-        if (StringUtils.isBlank(ericIdentity)) {
+        if (StringUtils.isBlank(ericId)) {
             logger.error("Unauthorised request received without eric identity");
             response.sendError(HttpServletResponse.SC_FORBIDDEN);
             return;
         }
 
-        String ericId = request.getHeader("ERIC-Identity-Type");
+        String ericIdType = request.getHeader("ERIC-Identity-Type");
 
-        if (StringUtils.isBlank(ericId) ||
-                ! (ericId.equalsIgnoreCase("key") || ericId.equalsIgnoreCase("oauth2"))) {
+        if (StringUtils.isBlank(ericIdType) ||
+                ! (ericIdType.equalsIgnoreCase("key") || ericIdType.equalsIgnoreCase("oauth2"))) {
             logger.error("Unauthorised request received without eric identity type");
             response.sendError(HttpServletResponse.SC_FORBIDDEN);
             return;

--- a/src/main/java/uk/gov/companieshouse/disqualifiedofficersdataapi/config/WebSecurityConfig.java
+++ b/src/main/java/uk/gov/companieshouse/disqualifiedofficersdataapi/config/WebSecurityConfig.java
@@ -1,0 +1,49 @@
+package uk.gov.companieshouse.disqualifiedofficersdataapi.config;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.method.configuration.EnableGlobalMethodSecurity;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.builders.WebSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.authentication.www.BasicAuthenticationFilter;
+import uk.gov.companieshouse.disqualifiedofficersdataapi.auth.EricTokenAuthenticationFilter;
+import uk.gov.companieshouse.logging.Logger;
+
+@Configuration
+@EnableWebSecurity
+@EnableGlobalMethodSecurity(prePostEnabled = true)
+public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
+
+    @Autowired
+    private Logger logger;
+
+    /**
+     * Configure Http Security.
+     */
+    @Override
+    protected void configure(HttpSecurity http) throws Exception {
+        http.httpBasic().disable()
+                .csrf().disable()
+                .formLogin().disable()
+                .logout().disable()
+                .sessionManagement()
+                .sessionCreationPolicy(SessionCreationPolicy.STATELESS)
+                .and()
+                .addFilterAt(new EricTokenAuthenticationFilter(logger),
+                        BasicAuthenticationFilter.class)
+                .authorizeRequests()
+                .anyRequest().permitAll();
+    }
+
+    /**
+     * Configure Web Security.
+     */
+    @Override
+    public void configure(WebSecurity web) throws Exception {
+        // Excluding healthcheck endpoint from security filter
+        web.ignoring().antMatchers("/disqualified-officers/healthcheck");
+    }
+}

--- a/src/test/java/uk/gov/companieshouse/disqualifiedofficersdataapi/auth/EricTokenAuthenticationFilterTest.java
+++ b/src/test/java/uk/gov/companieshouse/disqualifiedofficersdataapi/auth/EricTokenAuthenticationFilterTest.java
@@ -1,0 +1,77 @@
+package uk.gov.companieshouse.disqualifiedofficersdataapi.auth;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.springframework.boot.test.context.SpringBootTest;
+import uk.gov.companieshouse.logging.Logger;
+
+import javax.servlet.FilterChain;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@SpringBootTest
+public class EricTokenAuthenticationFilterTest {
+
+    @Mock
+    Logger logger;
+    @Mock
+    HttpServletRequest request;
+    @Mock
+    HttpServletResponse response;
+    @Mock
+    FilterChain filterChain;
+
+    EricTokenAuthenticationFilter filter;
+
+    @BeforeEach
+    void setup() {
+        filter = new EricTokenAuthenticationFilter(logger);
+    }
+
+    @Test
+    void ericTokenFilterAllowsCallWithKeyCredentials() throws Exception {
+        when(request.getHeader("ERIC-Identity")).thenReturn("TEST");
+        when(request.getHeader("ERIC-Identity-Type")).thenReturn("KEY");
+
+        filter.doFilterInternal(request, response, filterChain);
+
+        verify(filterChain, times(1)).doFilter(request, response);
+    }
+
+    @Test
+    void ericTokenFilterAllowsCallWithOauth2Credentials() throws Exception {
+        when(request.getHeader("ERIC-Identity")).thenReturn("TEST");
+        when(request.getHeader("ERIC-Identity-Type")).thenReturn("OAUTH2");
+
+        filter.doFilterInternal(request, response, filterChain);
+
+        verify(filterChain, times(1)).doFilter(request, response);
+    }
+
+    @Test
+    void ericTokenFilterBlocksCallWithEmptyIdentity() throws Exception {
+        when(request.getHeader("ERIC-Identity")).thenReturn("");
+        when(request.getHeader("ERIC-Identity-Type")).thenReturn("OAUTH2");
+
+        filter.doFilterInternal(request, response, filterChain);
+
+        verify(filterChain, times(0)).doFilter(request, response);
+        verify(response, times(1)).sendError(403);
+    }
+
+    @Test
+    void ericTokenFilterBlocksCallWithIncorrectIdentityType() throws Exception {
+        when(request.getHeader("ERIC-Identity")).thenReturn("TEST");
+        when(request.getHeader("ERIC-Identity-Type")).thenReturn("INVALID");
+
+        filter.doFilterInternal(request, response, filterChain);
+
+        verify(filterChain, times(0)).doFilter(request, response);
+        verify(response, times(1)).sendError(403);
+    }
+}


### PR DESCRIPTION
This pr adds a filter that checks the eric headers sent in requests. If the header are incorrect the service throws a 403. Also included are fixes to the integration tests to account for this and a new test for the 403 scenario.

**Resolves:**
- DSND-1077