### PR TITLE
Move ignore fields to object mapper to prevent deleted data containing fields get request does not

### DIFF
--- a/src/main/java/uk/gov/companieshouse/disqualifiedofficersdataapi/config/ApplicationConfig.java
+++ b/src/main/java/uk/gov/companieshouse/disqualifiedofficersdataapi/config/ApplicationConfig.java
@@ -11,12 +11,17 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.mongodb.core.convert.MongoCustomConversions;
 import uk.gov.companieshouse.api.chskafka.ChangedResource;
+import uk.gov.companieshouse.api.disqualification.CorporateDisqualificationApi;
+import uk.gov.companieshouse.api.disqualification.NaturalDisqualificationApi;
+import uk.gov.companieshouse.api.disqualification.PermissionToAct;
 import uk.gov.companieshouse.disqualifiedofficersdataapi.api.ResourceChangedRequest;
 import uk.gov.companieshouse.disqualifiedofficersdataapi.api.ResourceChangedRequestMapper;
 import uk.gov.companieshouse.disqualifiedofficersdataapi.converter.DisqualifiedCorporateOfficerReadConverter;
 import uk.gov.companieshouse.disqualifiedofficersdataapi.converter.DisqualifiedCorporateOfficerWriteConverter;
 import uk.gov.companieshouse.disqualifiedofficersdataapi.converter.DisqualifiedNaturalOfficerReadConverter;
 import uk.gov.companieshouse.disqualifiedofficersdataapi.converter.DisqualifiedNaturalOfficerWriteConverter;
+import uk.gov.companieshouse.disqualifiedofficersdataapi.model.DisqualificationApiMixIn;
+import uk.gov.companieshouse.disqualifiedofficersdataapi.model.PermissionToActMixIn;
 import uk.gov.companieshouse.disqualifiedofficersdataapi.serialization.LocalDateDeSerializer;
 import uk.gov.companieshouse.disqualifiedofficersdataapi.serialization.LocalDateSerializer;
 
@@ -63,6 +68,9 @@ public class ApplicationConfig {
         objectMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
         objectMapper.configure(SerializationFeature.FAIL_ON_EMPTY_BEANS, false);
         objectMapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
+        objectMapper.addMixIn(NaturalDisqualificationApi.class, DisqualificationApiMixIn.class);
+        objectMapper.addMixIn(CorporateDisqualificationApi.class, DisqualificationApiMixIn.class);
+        objectMapper.addMixIn(PermissionToAct.class, PermissionToActMixIn.class);
         SimpleModule module = new SimpleModule();
         module.addSerializer(LocalDate.class, new LocalDateSerializer());
         module.addDeserializer(LocalDate.class, new LocalDateDeSerializer());

--- a/src/main/java/uk/gov/companieshouse/disqualifiedofficersdataapi/controller/DisqualifiedOfficerController.java
+++ b/src/main/java/uk/gov/companieshouse/disqualifiedofficersdataapi/controller/DisqualifiedOfficerController.java
@@ -16,7 +16,6 @@ import uk.gov.companieshouse.api.disqualification.CorporateDisqualificationApi;
 import uk.gov.companieshouse.api.disqualification.InternalCorporateDisqualificationApi;
 import uk.gov.companieshouse.api.disqualification.InternalNaturalDisqualificationApi;
 import uk.gov.companieshouse.api.disqualification.NaturalDisqualificationApi;
-import uk.gov.companieshouse.api.disqualification.PermissionToAct;
 import uk.gov.companieshouse.disqualifiedofficersdataapi.model.*;
 import uk.gov.companieshouse.disqualifiedofficersdataapi.service.DisqualifiedOfficerService;
 
@@ -91,13 +90,6 @@ public class DisqualifiedOfficerController {
                 officerId));
 
         NaturalDisqualificationDocument disqualification = service.retrieveNaturalDisqualification(officerId);
-        NaturalDisqualificationApi data = disqualification.getData();
-        if (data.getPermissionsToAct() != null) {
-            for (PermissionToAct permissionToAct : data.getPermissionsToAct()) {
-                permissionToAct.setPurpose(null);
-            }
-        }
-        data.setPersonNumber(null);
 
         return ResponseEntity.status(HttpStatus.OK).body(disqualification.getData());
     }
@@ -117,13 +109,6 @@ public class DisqualifiedOfficerController {
 
         CorporateDisqualificationDocument disqualification = service.retrieveCorporateDisqualification(
                 officerId);
-        CorporateDisqualificationApi data = disqualification.getData();
-        if (data.getPermissionsToAct() != null) {
-            for (PermissionToAct permissionToAct : data.getPermissionsToAct()) {
-                permissionToAct.setPurpose(null);
-            }
-        }
-        data.setPersonNumber(null);
 
         return ResponseEntity.status(HttpStatus.OK).body(disqualification.getData());
     }

--- a/src/main/java/uk/gov/companieshouse/disqualifiedofficersdataapi/model/DisqualificationApiMixIn.java
+++ b/src/main/java/uk/gov/companieshouse/disqualifiedofficersdataapi/model/DisqualificationApiMixIn.java
@@ -1,0 +1,7 @@
+package uk.gov.companieshouse.disqualifiedofficersdataapi.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+@JsonIgnoreProperties(value = {"person_number"}, allowGetters = true)
+public interface DisqualificationApiMixIn {
+}

--- a/src/main/java/uk/gov/companieshouse/disqualifiedofficersdataapi/model/PermissionToActMixIn.java
+++ b/src/main/java/uk/gov/companieshouse/disqualifiedofficersdataapi/model/PermissionToActMixIn.java
@@ -1,0 +1,7 @@
+package uk.gov.companieshouse.disqualifiedofficersdataapi.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+@JsonIgnoreProperties(value = {"purpose"}, allowGetters = true)
+public interface PermissionToActMixIn {
+}


### PR DESCRIPTION
This PR moves the nulling of fields into the object mapper configuration in order to null the same fields for deleted data as the get request when data is pulled from the mongo.

**Resolves**
DSND-1113