### PR TITLE
Omit blank fields when saving disqualification

### DIFF
--- a/src/itest/resources/json/output/retrieve_corporate_disqualified_officer.json
+++ b/src/itest/resources/json/output/retrieve_corporate_disqualified_officer.json
@@ -16,7 +16,6 @@
         "address_line_1": "Lucy Road",
         "address_line_2": "Skewen",
         "locality": "Neath",
-        "region": "",
         "country": "Wales",
         "postal_code": "SA10 6RR"
       },

--- a/src/itest/resources/json/output/retrieve_natural_disqualified_officer.json
+++ b/src/itest/resources/json/output/retrieve_natural_disqualified_officer.json
@@ -3,7 +3,6 @@
     "person_number": null,
     "etag": "7a0ba73f960315629fa36fc41b4d325881773245",
     "forename": "Dust",
-    "honours": "",
     "nationality": "British",
     "other_forenames": null,
     "surname": "KINDNESSLIQUOR",
@@ -19,7 +18,6 @@
                 "address_line_1": "Lucy Road",
                 "address_line_2": "Skewen",
                 "locality": "Neath",
-                "region": "",
                 "country": "Wales",
                 "postal_code": "SA10 6RR"
             },

--- a/src/main/java/uk/gov/companieshouse/disqualifiedofficersdataapi/config/ApplicationConfig.java
+++ b/src/main/java/uk/gov/companieshouse/disqualifiedofficersdataapi/config/ApplicationConfig.java
@@ -67,7 +67,7 @@ public class ApplicationConfig {
         ObjectMapper objectMapper = new ObjectMapper();
         objectMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
         objectMapper.configure(SerializationFeature.FAIL_ON_EMPTY_BEANS, false);
-        objectMapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
+        objectMapper.setSerializationInclusion(JsonInclude.Include.NON_EMPTY);
         objectMapper.addMixIn(NaturalDisqualificationApi.class, DisqualificationApiMixIn.class);
         objectMapper.addMixIn(CorporateDisqualificationApi.class, DisqualificationApiMixIn.class);
         objectMapper.addMixIn(PermissionToAct.class, PermissionToActMixIn.class);


### PR DESCRIPTION
This pr adds a filter to the database object mapper to stop blank fields being saved.

**Resolves:**
- DSND-1144