### PR TITLE
DSND-1544: Added internal app privileges checking.

### DIFF
--- a/src/itest/java/uk/gov/companieshouse/disqualifiedofficersdataapi/steps/CorporateDisqualificationSteps.java
+++ b/src/itest/java/uk/gov/companieshouse/disqualifiedofficersdataapi/steps/CorporateDisqualificationSteps.java
@@ -107,6 +107,7 @@ public class CorporateDisqualificationSteps {
         headers.set("x-request-id", this.contextId);
         headers.set("ERIC-Identity", "TEST-IDENTITY");
         headers.set("ERIC-Identity-Type", "KEY");
+        headers.set("ERIC-Authorised-Key-Privileges", "internal-app");
 
         HttpEntity request = new HttpEntity(data, headers);
         String uri = "/disqualified-officers/corporate/{officerId}/internal";

--- a/src/itest/java/uk/gov/companieshouse/disqualifiedofficersdataapi/steps/DisqualificationSteps.java
+++ b/src/itest/java/uk/gov/companieshouse/disqualifiedofficersdataapi/steps/DisqualificationSteps.java
@@ -21,10 +21,12 @@ import uk.gov.companieshouse.disqualifiedofficersdataapi.model.DisqualificationD
 import uk.gov.companieshouse.disqualifiedofficersdataapi.model.DisqualificationResourceType;
 import uk.gov.companieshouse.disqualifiedofficersdataapi.repository.DisqualifiedOfficerRepository;
 
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.doThrow;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.times;
 import static uk.gov.companieshouse.disqualifiedofficersdataapi.config.AbstractMongoConfig.mongoDBContainer;
 
 public class DisqualificationSteps {
@@ -67,6 +69,7 @@ public class DisqualificationSteps {
         headers.set("x-request-id", CucumberContext.CONTEXT.get("contextId"));
         headers.set("ERIC-Identity", "TEST-IDENTITY");
         headers.set("ERIC-Identity-Type", "KEY");
+        headers.set("ERIC-Authorised-Key-Privileges", "internal-app");
 
         HttpEntity<String> request = new HttpEntity<String>(null, headers);
 

--- a/src/itest/java/uk/gov/companieshouse/disqualifiedofficersdataapi/steps/NaturalDisqualificationSteps.java
+++ b/src/itest/java/uk/gov/companieshouse/disqualifiedofficersdataapi/steps/NaturalDisqualificationSteps.java
@@ -109,6 +109,7 @@ public class NaturalDisqualificationSteps {
         headers.set("x-request-id", this.contextId);
         headers.set("ERIC-Identity", "TEST-IDENTITY");
         headers.set("ERIC-Identity-Type", "KEY");
+        headers.set("ERIC-Authorised-Key-Privileges", "internal-app");
 
         HttpEntity<String> request = new HttpEntity<String>(data, headers);
         String uri = "/disqualified-officers/natural/{officerId}/internal";

--- a/src/itest/resources/features/officer_disq_status_response_codes.feature
+++ b/src/itest/resources/features/officer_disq_status_response_codes.feature
@@ -43,4 +43,4 @@ Scenario: Processing disqualified officers information unsuccessfully after inte
   Scenario: Proccessing disqualified officers information without ERIC headers
     Given disqualified officers data api service is running
     When I send natural PUT request without ERIC headers
-    Then I should receive 403 status code
+    Then I should receive 401 status code

--- a/src/main/java/uk/gov/companieshouse/disqualifiedofficersdataapi/auth/EricTokenAuthenticationFilter.java
+++ b/src/main/java/uk/gov/companieshouse/disqualifiedofficersdataapi/auth/EricTokenAuthenticationFilter.java
@@ -1,12 +1,14 @@
 package uk.gov.companieshouse.disqualifiedofficersdataapi.auth;
 
 import java.io.IOException;
+import java.util.Optional;
 import javax.servlet.FilterChain;
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
 import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.ArrayUtils;
 import org.springframework.web.filter.OncePerRequestFilter;
 import uk.gov.companieshouse.logging.Logger;
 
@@ -22,23 +24,45 @@ public class EricTokenAuthenticationFilter extends OncePerRequestFilter {
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
                                     FilterChain filterChain) throws ServletException, IOException {
 
-        String ericId = request.getHeader("ERIC-Identity");
+        String ericIdentity = request.getHeader("ERIC-Identity");
 
-        if (StringUtils.isBlank(ericId)) {
-            logger.error("Unauthorised request received without eric identity");
+        if (StringUtils.isBlank(ericIdentity)) {
+            logger.error("Request received without eric identity");
+            response.sendError(HttpServletResponse.SC_UNAUTHORIZED);
+            return;
+        }
+
+        String ericIdentityType = request.getHeader("ERIC-Identity-Type");
+
+        if (!("key".equalsIgnoreCase(ericIdentityType)
+                || ("oauth2".equalsIgnoreCase(ericIdentityType)))) {
+            logger.error("Request received without correct eric identity type");
+            response.sendError(HttpServletResponse.SC_UNAUTHORIZED);
+            return;
+        }
+
+        if (!isKeyAuthorised(request, ericIdentityType)) {
+            logger.info("Supplied key does not have sufficient privilege for the action");
             response.sendError(HttpServletResponse.SC_FORBIDDEN);
             return;
         }
 
-        String ericIdType = request.getHeader("ERIC-Identity-Type");
+        filterChain.doFilter(request,response);
+    }
 
-        if (StringUtils.isBlank(ericIdType) ||
-                ! (ericIdType.equalsIgnoreCase("key") || ericIdType.equalsIgnoreCase("oauth2"))) {
-            logger.error("Unauthorised request received without eric identity type");
-            response.sendError(HttpServletResponse.SC_FORBIDDEN);
-            return;
-        }
+    private boolean isKeyAuthorised(HttpServletRequest request, String ericIdentityType) {
+        String[] privileges = getApiKeyPrivileges(request);
 
-        filterChain.doFilter(request, response);
+        return request.getMethod().equals("GET")
+                || (ericIdentityType.equalsIgnoreCase("Key")
+                && ArrayUtils.contains(privileges, "internal-app"));
+    }
+
+    private String[] getApiKeyPrivileges(HttpServletRequest request) {
+        String commaSeparatedPrivilegeString = request.getHeader("ERIC-Authorised-Key-Privileges");
+
+        return Optional.ofNullable(commaSeparatedPrivilegeString)
+                .map(s -> s.split(","))
+                .orElse(new String[]{});
     }
 }


### PR DESCRIPTION
* Authorise OAUTH2 requests only if they are GET requests
* Authorise KEY requests only if they have internal app privileges
* Added GET mapping tests for disqualifiedOfficers controller

[DSND-1544](https://companieshouse.atlassian.net/browse/DSND-1544)

[DSND-1544]: https://companieshouse.atlassian.net/browse/DSND-1544?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ