### PR TITLE
DSND-1579 Fix handling of is latest record

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,8 +18,8 @@
         <start-class>uk.gov.companieshouse.disqualifiedofficersdataapi.DisqualifiedOfficersDataApiApplication</start-class>
 
         <maven-build-helper-plugin.version>3.2.0</maven-build-helper-plugin.version>
-        <spring-boot-dependencies.version>2.6.4</spring-boot-dependencies.version>
-        <spring-boot-maven-plugin.version>2.6.4</spring-boot-maven-plugin.version>
+        <spring-boot-dependencies.version>2.7.9</spring-boot-dependencies.version>
+        <spring-boot-maven-plugin.version>2.7.9</spring-boot-maven-plugin.version>
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
 

--- a/src/main/java/uk/gov/companieshouse/disqualifiedofficersdataapi/repository/DisqualifiedOfficerRepository.java
+++ b/src/main/java/uk/gov/companieshouse/disqualifiedofficersdataapi/repository/DisqualifiedOfficerRepository.java
@@ -9,7 +9,4 @@ import java.util.List;
 
 @Repository
 public interface DisqualifiedOfficerRepository extends MongoRepository<DisqualificationDocument, String> {
-
-    @Query("{'_id': ?0, 'updated.at':{$gte : { \"$date\" : \"?1\" } }}")
-    List<DisqualificationDocument> findUpdatedDisqualification(String officerId, String at);
 }

--- a/src/main/java/uk/gov/companieshouse/disqualifiedofficersdataapi/service/DisqualifiedOfficerService.java
+++ b/src/main/java/uk/gov/companieshouse/disqualifiedofficersdataapi/service/DisqualifiedOfficerService.java
@@ -61,7 +61,7 @@ public class DisqualifiedOfficerService {
 
         Optional<DisqualificationDocument> existingDocument = repository.findById(officerId);
 
-        // If the document does not exist OR the delta_at in the request is after the new delta_at
+        // If the document does not exist OR the delta_at in the request is after the delta_at being processed
         if (existingDocument.isEmpty() ||
                 StringUtils.isBlank(existingDocument.get().getDeltaAt()) ||
                 isLatestRecord(requestBody.getInternalData().getDeltaAt(), existingDocument.get())) {

--- a/src/main/java/uk/gov/companieshouse/disqualifiedofficersdataapi/service/DisqualifiedOfficerService.java
+++ b/src/main/java/uk/gov/companieshouse/disqualifiedofficersdataapi/service/DisqualifiedOfficerService.java
@@ -147,7 +147,7 @@ public class DisqualifiedOfficerService {
     }
 
     private boolean isLatestRecord(OffsetDateTime deltaAt, Optional<DisqualificationDocument> existingDocument) {
-        // If the document does not exist OR the delta_at in the request is after the new delta_at
+        // If the document does not exist OR the delta_at is blank/null OR the delta_at in the request is after the new delta_at
         return  existingDocument.isEmpty() ||
                 StringUtils.isBlank(existingDocument.get().getDeltaAt()) ||
                 deltaAt.isAfter(ZonedDateTime.parse(existingDocument.get().getDeltaAt(), FORMATTER)

--- a/src/test/java/uk/gov/companieshouse/disqualifiedofficersdataapi/service/DisqualifiedOfficerServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/disqualifiedofficersdataapi/service/DisqualifiedOfficerServiceTest.java
@@ -3,15 +3,18 @@ package uk.gov.companieshouse.disqualifiedofficersdataapi.service;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.ArgumentCaptor;
-import org.mockito.Captor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.companieshouse.api.disqualification.*;
 import uk.gov.companieshouse.disqualifiedofficersdataapi.api.DisqualifiedOfficerApiService;
 import uk.gov.companieshouse.disqualifiedofficersdataapi.api.ResourceChangedRequest;
-import uk.gov.companieshouse.disqualifiedofficersdataapi.model.*;
+import uk.gov.companieshouse.disqualifiedofficersdataapi.model.CorporateDisqualificationDocument;
+import uk.gov.companieshouse.disqualifiedofficersdataapi.model.Created;
+import uk.gov.companieshouse.disqualifiedofficersdataapi.model.DisqualificationDocument;
+import uk.gov.companieshouse.disqualifiedofficersdataapi.model.DisqualificationResourceType;
+import uk.gov.companieshouse.disqualifiedofficersdataapi.model.NaturalDisqualificationDocument;
+import uk.gov.companieshouse.disqualifiedofficersdataapi.model.Updated;
 import uk.gov.companieshouse.disqualifiedofficersdataapi.repository.CorporateDisqualifiedOfficerRepository;
 import uk.gov.companieshouse.disqualifiedofficersdataapi.repository.DisqualifiedOfficerRepository;
 import uk.gov.companieshouse.disqualifiedofficersdataapi.repository.NaturalDisqualifiedOfficerRepository;
@@ -19,7 +22,6 @@ import uk.gov.companieshouse.disqualifiedofficersdataapi.transform.Disqualificat
 
 import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
-import java.time.format.DateTimeFormatter;
 import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;


### PR DESCRIPTION
* Request body's `delta_at` now compared to existing document's `delta_at` to determine if latest record. If null/empty `delta_at` or no document, then document persisted anyway.
* Added unit tests to test isLatestRecord boolean return.
* Updated spring boot dependency version to 2.7.9.
* Completed local testing for both corporate and natural.

[DSND-1579](https://companieshouse.atlassian.net/browse/DSND-1579)