### PR TITLE
Feature/bi 13707 add person number field

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>uk.gov.companieshouse</groupId>
         <artifactId>companies-house-parent</artifactId>
-        <version>2.1.5</version>
+        <version>2.1.6</version>
     </parent>
     <artifactId>disqualified-officers-data-api</artifactId>
     <version>unversioned</version>

--- a/src/main/java/uk/gov/companieshouse/disqualifiedofficersdataapi/config/ApplicationConfig.java
+++ b/src/main/java/uk/gov/companieshouse/disqualifiedofficersdataapi/config/ApplicationConfig.java
@@ -20,7 +20,6 @@ import uk.gov.companieshouse.disqualifiedofficersdataapi.converter.DisqualifiedC
 import uk.gov.companieshouse.disqualifiedofficersdataapi.converter.DisqualifiedCorporateOfficerWriteConverter;
 import uk.gov.companieshouse.disqualifiedofficersdataapi.converter.DisqualifiedNaturalOfficerReadConverter;
 import uk.gov.companieshouse.disqualifiedofficersdataapi.converter.DisqualifiedNaturalOfficerWriteConverter;
-import uk.gov.companieshouse.disqualifiedofficersdataapi.model.DisqualificationApiMixIn;
 import uk.gov.companieshouse.disqualifiedofficersdataapi.model.PermissionToActMixIn;
 import uk.gov.companieshouse.disqualifiedofficersdataapi.serialization.LocalDateDeSerializer;
 import uk.gov.companieshouse.disqualifiedofficersdataapi.serialization.LocalDateSerializer;
@@ -68,8 +67,6 @@ public class ApplicationConfig {
         objectMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
         objectMapper.configure(SerializationFeature.FAIL_ON_EMPTY_BEANS, false);
         objectMapper.setSerializationInclusion(JsonInclude.Include.NON_EMPTY);
-        objectMapper.addMixIn(NaturalDisqualificationApi.class, DisqualificationApiMixIn.class);
-        objectMapper.addMixIn(CorporateDisqualificationApi.class, DisqualificationApiMixIn.class);
         objectMapper.addMixIn(PermissionToAct.class, PermissionToActMixIn.class);
         SimpleModule module = new SimpleModule();
         module.addSerializer(LocalDate.class, new LocalDateSerializer());

--- a/src/main/java/uk/gov/companieshouse/disqualifiedofficersdataapi/model/DisqualificationApiMixIn.java
+++ b/src/main/java/uk/gov/companieshouse/disqualifiedofficersdataapi/model/DisqualificationApiMixIn.java
@@ -1,4 +1,0 @@
-package uk.gov.companieshouse.disqualifiedofficersdataapi.model;
-
-public interface DisqualificationApiMixIn {
-}

--- a/src/main/java/uk/gov/companieshouse/disqualifiedofficersdataapi/model/DisqualificationApiMixIn.java
+++ b/src/main/java/uk/gov/companieshouse/disqualifiedofficersdataapi/model/DisqualificationApiMixIn.java
@@ -1,7 +1,4 @@
 package uk.gov.companieshouse.disqualifiedofficersdataapi.model;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-
-@JsonIgnoreProperties(value = {"person_number"}, allowGetters = true)
 public interface DisqualificationApiMixIn {
 }


### PR DESCRIPTION
Resolves [BI-13707](https://companieshouse.atlassian.net/browse/BI-13707) 

A new interface to create a mixin  class with annotation `@JsonIgnoreProperties(value = {"person_number"}, allowGetters = true)` ` was added in [this commit  ](https://github.com/companieshouse/disqualified-officers-data-api/commit/e4a5f6eb59e975aa967498913de9414c90617cc4) to prevent it appearing which was probably the cause of it not appearing in the GET response. 
After removing annotation, this is the result for both natural and corporate officers

<img width="1239" alt="Screenshot 2024-07-11 at 10 52 22" src="https://github.com/companieshouse/disqualified-officers-data-api/assets/59569724/93477dd8-3a4a-497e-a2a0-ed1e6f368cd3">
<img width="1239" alt="Screenshot 2024-07-11 at 10 51 42" src="https://github.com/companieshouse/disqualified-officers-data-api/assets/59569724/964ca90b-4569-4fdc-9be9-db948eae474c">


[BI-13707]: https://companieshouse.atlassian.net/browse/BI-13707?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ