### PR TITLE
BI-13963: Round published_at timestamp to nearest second

### DIFF
--- a/src/main/java/uk/gov/companieshouse/disqualifiedofficersdataapi/api/DisqualifiedOfficerApiService.java
+++ b/src/main/java/uk/gov/companieshouse/disqualifiedofficersdataapi/api/DisqualifiedOfficerApiService.java
@@ -12,7 +12,6 @@ import uk.gov.companieshouse.disqualifiedofficersdataapi.exceptions.ServiceUnava
 import uk.gov.companieshouse.logging.Logger;
 
 import java.util.function.Function;
-import java.util.function.Supplier;
 
 @Service
 public class DisqualifiedOfficerApiService {
@@ -29,7 +28,6 @@ public class DisqualifiedOfficerApiService {
     public DisqualifiedOfficerApiService(@Value("${chs.kafka.api.endpoint}") String chsKafkaUrl,
             ApiClientService apiClientService,
             Logger logger,
-            Supplier<String> timestampGenerator,
             Function<ResourceChangedRequest, ChangedResource> mapper) {
         this.chsKafkaUrl = chsKafkaUrl;
         this.apiClientService = apiClientService;

--- a/src/main/java/uk/gov/companieshouse/disqualifiedofficersdataapi/config/ApplicationConfig.java
+++ b/src/main/java/uk/gov/companieshouse/disqualifiedofficersdataapi/config/ApplicationConfig.java
@@ -6,13 +6,14 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.databind.module.SimpleModule;
 
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
 import java.util.function.Function;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.mongodb.core.convert.MongoCustomConversions;
 import uk.gov.companieshouse.api.chskafka.ChangedResource;
-import uk.gov.companieshouse.api.disqualification.CorporateDisqualificationApi;
-import uk.gov.companieshouse.api.disqualification.NaturalDisqualificationApi;
 import uk.gov.companieshouse.api.disqualification.PermissionToAct;
 import uk.gov.companieshouse.disqualifiedofficersdataapi.api.ResourceChangedRequest;
 import uk.gov.companieshouse.disqualifiedofficersdataapi.api.ResourceChangedRequestMapper;
@@ -25,12 +26,15 @@ import uk.gov.companieshouse.disqualifiedofficersdataapi.serialization.LocalDate
 import uk.gov.companieshouse.disqualifiedofficersdataapi.serialization.LocalDateSerializer;
 
 import java.time.LocalDate;
-import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.function.Supplier;
 
 @Configuration
 public class ApplicationConfig {
+
+    private final DateTimeFormatter dateTimeFormatter = DateTimeFormatter
+            .ofPattern("yyyy-MM-dd'T'HH:mm:ss")
+            .withZone(ZoneOffset.UTC);
 
     /**
      * mongoCustomConversions.
@@ -47,13 +51,13 @@ public class ApplicationConfig {
     }
 
     @Bean
-    public Supplier<String> offsetDateTimeGenerator() {
-        return () -> String.valueOf(OffsetDateTime.now());
+    public Supplier<String> timestampGenerator() {
+        return () -> dateTimeFormatter.format(Instant.now());
     }
 
     @Bean
     public Function<ResourceChangedRequest, ChangedResource> mapper() {
-        ResourceChangedRequestMapper mapper = new ResourceChangedRequestMapper(offsetDateTimeGenerator());
+        ResourceChangedRequestMapper mapper = new ResourceChangedRequestMapper(timestampGenerator());
         return mapper::mapChangedResource;
     }
 

--- a/src/test/java/uk/gov/companieshouse/disqualifiedofficersdataapi/api/TimestampGeneratorTest.java
+++ b/src/test/java/uk/gov/companieshouse/disqualifiedofficersdataapi/api/TimestampGeneratorTest.java
@@ -1,0 +1,18 @@
+package uk.gov.companieshouse.disqualifiedofficersdataapi.api;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.function.Supplier;
+import org.junit.jupiter.api.Test;
+import uk.gov.companieshouse.disqualifiedofficersdataapi.config.ApplicationConfig;
+
+class TimestampGeneratorTest {
+
+    private final Supplier<String> offsetDateTimeGenerator = new ApplicationConfig().timestampGenerator();
+
+    @Test
+    void shouldReturnFormattedTimestampString() {
+        String timestamp = offsetDateTimeGenerator.get();
+        assertTrue(timestamp.matches("^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}$"));
+    }
+}


### PR DESCRIPTION
Changed the offsetDateTimeGenerator() bean to use a custom formatted instant value

[BI-13963](https://companieshouse.atlassian.net/browse/BI-13963)

[BI-13963]: https://companieshouse.atlassian.net/browse/BI-13963?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ