### PR TITLE
DSND-3029: Change processing order for upserts

### DIFF
--- a/src/itest/resources/features/officer_disq_status_response_codes.feature
+++ b/src/itest/resources/features/officer_disq_status_response_codes.feature
@@ -25,11 +25,10 @@ Scenario: Processing disqualified officers information unsuccessfully after inte
     And I send natural PUT request with payload "<data>" file
     Then I should receive 503 status code
     And the CHS Kafka API is invoked with "<officerId>"
-    And nothing is persisted in the database
-
+    And a document is persisted to the database
     Examples:
-        | data                         | officerId  | result                                |
-        | natural_disqualified_officer | 1234567890 | retrieve_natural_disqualified_officer |
+        | data                         | officerId  |
+        | natural_disqualified_officer | 1234567890 |
 
   Scenario: Processing disqualified officers information while database is down
 


### PR DESCRIPTION
* Reversed the order of processing to save before publishing the change to kafka
* Changed the staleness check to allow retried deltas
* Updated the unit and integration tests and removed some code smells
[DSND-3029](https://companieshouse.atlassian.net/browse/DSND-3029)