### PR TITLE
DSND-2875: Use a custom exception for cases where document not found.

### DIFF
--- a/src/main/java/uk/gov/companieshouse/disqualifiedofficersdataapi/config/ExceptionHandlerConfig.java
+++ b/src/main/java/uk/gov/companieshouse/disqualifiedofficersdataapi/config/ExceptionHandlerConfig.java
@@ -17,6 +17,7 @@ import uk.gov.companieshouse.disqualifiedofficersdataapi.exceptions.BadRequestEx
 import uk.gov.companieshouse.disqualifiedofficersdataapi.exceptions.ConflictException;
 import uk.gov.companieshouse.disqualifiedofficersdataapi.exceptions.InternalServerErrorException;
 import uk.gov.companieshouse.disqualifiedofficersdataapi.exceptions.MethodNotAllowedException;
+import uk.gov.companieshouse.disqualifiedofficersdataapi.exceptions.NotFoundException;
 import uk.gov.companieshouse.disqualifiedofficersdataapi.exceptions.ServiceUnavailableException;
 import uk.gov.companieshouse.logging.Logger;
 import uk.gov.companieshouse.logging.LoggerFactory;
@@ -54,13 +55,13 @@ public class ExceptionHandlerConfig {
     }
 
     /**
-     * IllegalArgumentException exception handler.
+     * NotFoundException handler.
      *
      * @param ex      exception to handle.
      * @param request request.
      * @return error response to return.
      */
-    @ExceptionHandler(value = {IllegalArgumentException.class})
+    @ExceptionHandler(value = {NotFoundException.class})
     public ResponseEntity<Object> handleNotFoundException(Exception ex, WebRequest request) {
         LOGGER.error(String.format("Resource not found, response code: %s",
                 HttpStatus.NOT_FOUND), ex);

--- a/src/main/java/uk/gov/companieshouse/disqualifiedofficersdataapi/exceptions/NotFoundException.java
+++ b/src/main/java/uk/gov/companieshouse/disqualifiedofficersdataapi/exceptions/NotFoundException.java
@@ -1,0 +1,8 @@
+package uk.gov.companieshouse.disqualifiedofficersdataapi.exceptions;
+
+public class NotFoundException extends RuntimeException {
+
+    public NotFoundException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/disqualifiedofficersdataapi/logging/RequestLoggingFilter.java
+++ b/src/main/java/uk/gov/companieshouse/disqualifiedofficersdataapi/logging/RequestLoggingFilter.java
@@ -15,6 +15,7 @@ import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 import uk.gov.companieshouse.disqualifiedofficersdataapi.exceptions.BadGatewayException;
 import uk.gov.companieshouse.disqualifiedofficersdataapi.exceptions.InternalServerErrorException;
+import uk.gov.companieshouse.disqualifiedofficersdataapi.exceptions.NotFoundException;
 import uk.gov.companieshouse.logging.Logger;
 import uk.gov.companieshouse.logging.LoggerFactory;
 import uk.gov.companieshouse.logging.util.RequestLogger;
@@ -39,7 +40,7 @@ public class RequestLoggingFilter extends OncePerRequestFilter implements Reques
                 .orElse(UUID.randomUUID().toString()));
         try {
             filterChain.doFilter(request, response);
-        } catch (BadGatewayException | IllegalArgumentException | InternalServerErrorException ex) {
+        } catch (BadGatewayException | NotFoundException | InternalServerErrorException ex) {
             LOGGER.info("Recoverable exception: %s".formatted(Arrays.toString(ex.getStackTrace())),
                     DataMapHolder.getLogMap());
             throw ex;

--- a/src/main/java/uk/gov/companieshouse/disqualifiedofficersdataapi/service/DisqualifiedOfficerService.java
+++ b/src/main/java/uk/gov/companieshouse/disqualifiedofficersdataapi/service/DisqualifiedOfficerService.java
@@ -10,6 +10,7 @@ import uk.gov.companieshouse.api.disqualification.InternalNaturalDisqualificatio
 import uk.gov.companieshouse.disqualifiedofficersdataapi.api.DisqualifiedOfficerApiService;
 import uk.gov.companieshouse.disqualifiedofficersdataapi.api.ResourceChangedRequest;
 import uk.gov.companieshouse.disqualifiedofficersdataapi.exceptions.BadGatewayException;
+import uk.gov.companieshouse.disqualifiedofficersdataapi.exceptions.NotFoundException;
 import uk.gov.companieshouse.disqualifiedofficersdataapi.logging.DataMapHolder;
 import uk.gov.companieshouse.disqualifiedofficersdataapi.model.CorporateDisqualificationDocument;
 import uk.gov.companieshouse.disqualifiedofficersdataapi.model.Created;
@@ -133,11 +134,11 @@ public class DisqualifiedOfficerService {
                 naturalRepository.findById(officerId)
                         .orElseGet(() -> {
                             LOGGER.info("Record not found in MongoDB", DataMapHolder.getLogMap());
-                            throw new IllegalArgumentException("Record no found in MongoDB");
+                            throw new NotFoundException("Record no found in MongoDB");
                         });
         if (disqualificationDocument.isCorporateOfficer()) {
             LOGGER.info("Natural type record not found in MongoDB", DataMapHolder.getLogMap());
-            throw new IllegalArgumentException("Natural type record not found in MongoDB");
+            throw new NotFoundException("Natural type record not found in MongoDB");
         }
         return disqualificationDocument;
     }
@@ -147,11 +148,11 @@ public class DisqualifiedOfficerService {
                 corporateRepository.findById(officerId)
                         .orElseGet(() -> {
                             LOGGER.info("Record not found in MongoDB", DataMapHolder.getLogMap());
-                            throw new IllegalArgumentException("Record no found in MongoDB");
+                            throw new NotFoundException("Record no found in MongoDB");
                         });
         if (!disqualificationDocument.isCorporateOfficer()) {
             LOGGER.info("Corporate type record not found in MongoDB", DataMapHolder.getLogMap());
-            throw new IllegalArgumentException("Corporate type record not found in MongoDB");
+            throw new NotFoundException("Corporate type record not found in MongoDB");
         }
         return disqualificationDocument;
     }

--- a/src/test/java/uk/gov/companieshouse/disqualifiedofficersdataapi/api/controller/DisqualifiedOfficerControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/disqualifiedofficersdataapi/api/controller/DisqualifiedOfficerControllerTest.java
@@ -194,7 +194,7 @@ class DisqualifiedOfficerControllerTest {
 
     @Test
     @DisplayName("Disqualified Officer PUT request - NotFoundException 404 not found")
-    void callDisqualifiedOfficerPutRequestIllegalArgument() throws Exception {
+    void callDisqualifiedOfficerPutRequestNotFound() throws Exception {
         InternalNaturalDisqualificationApi request = new InternalNaturalDisqualificationApi();
         request.setInternalData(new InternalDisqualificationApiInternalData());
         request.setExternalData(new NaturalDisqualificationApi());

--- a/src/test/java/uk/gov/companieshouse/disqualifiedofficersdataapi/api/controller/DisqualifiedOfficerControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/disqualifiedofficersdataapi/api/controller/DisqualifiedOfficerControllerTest.java
@@ -46,6 +46,7 @@ import uk.gov.companieshouse.disqualifiedofficersdataapi.controller.Disqualified
 import uk.gov.companieshouse.disqualifiedofficersdataapi.exceptions.BadRequestException;
 import uk.gov.companieshouse.disqualifiedofficersdataapi.exceptions.ConflictException;
 import uk.gov.companieshouse.disqualifiedofficersdataapi.exceptions.MethodNotAllowedException;
+import uk.gov.companieshouse.disqualifiedofficersdataapi.exceptions.NotFoundException;
 import uk.gov.companieshouse.disqualifiedofficersdataapi.exceptions.ServiceUnavailableException;
 import uk.gov.companieshouse.disqualifiedofficersdataapi.model.DeleteRequestParameters;
 import uk.gov.companieshouse.disqualifiedofficersdataapi.model.NaturalDisqualificationDocument;
@@ -192,13 +193,13 @@ class DisqualifiedOfficerControllerTest {
 
 
     @Test
-    @DisplayName("Disqualified Officer PUT request - IllegalArgumentException status code 404 not found")
+    @DisplayName("Disqualified Officer PUT request - NotFoundException 404 not found")
     void callDisqualifiedOfficerPutRequestIllegalArgument() throws Exception {
         InternalNaturalDisqualificationApi request = new InternalNaturalDisqualificationApi();
         request.setInternalData(new InternalDisqualificationApiInternalData());
         request.setExternalData(new NaturalDisqualificationApi());
 
-        doThrow(new IllegalArgumentException())
+        doThrow(NotFoundException.class)
                 .when(disqualifiedOfficerService).processNaturalDisqualification(anyString(), anyString(),
                         isA(InternalNaturalDisqualificationApi.class));
 
@@ -449,9 +450,9 @@ class DisqualifiedOfficerControllerTest {
     }
 
     @Test
-    @DisplayName("DisqualifiedOfficer GET request - DocumentNotFoundException status code 404 resource not found")
-    void callDisqualifiedOfficerGetRequestDocumentnotFound() throws Exception {
-        doThrow(new IllegalArgumentException("Document not found"))
+    @DisplayName("DisqualifiedOfficer GET request - NotFoundException status code 404 resource not found")
+    void callDisqualifiedOfficerGetRequestWhenDocumentNotFound() throws Exception {
+        doThrow(new NotFoundException("Document not found"))
                 .when(disqualifiedOfficerService).retrieveNaturalDisqualification(anyString());
 
         mockMvc.perform(get(NATURAL_GET_URL)

--- a/src/test/java/uk/gov/companieshouse/disqualifiedofficersdataapi/controller/DisqualifiedOfficerControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/disqualifiedofficersdataapi/controller/DisqualifiedOfficerControllerTest.java
@@ -1,4 +1,4 @@
-package uk.gov.companieshouse.disqualifiedofficersdataapi.api.controller;
+package uk.gov.companieshouse.disqualifiedofficersdataapi.controller;
 
 import static org.hamcrest.Matchers.containsString;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -42,7 +42,6 @@ import uk.gov.companieshouse.api.disqualification.InternalNaturalDisqualificatio
 import uk.gov.companieshouse.api.disqualification.NaturalDisqualificationApi;
 import uk.gov.companieshouse.disqualifiedofficersdataapi.config.ExceptionHandlerConfig;
 import uk.gov.companieshouse.disqualifiedofficersdataapi.config.WebSecurityConfig;
-import uk.gov.companieshouse.disqualifiedofficersdataapi.controller.DisqualifiedOfficerController;
 import uk.gov.companieshouse.disqualifiedofficersdataapi.exceptions.BadRequestException;
 import uk.gov.companieshouse.disqualifiedofficersdataapi.exceptions.ConflictException;
 import uk.gov.companieshouse.disqualifiedofficersdataapi.exceptions.MethodNotAllowedException;


### PR DESCRIPTION
* Use custom made exception instead of generic IllegalArguementException when document not found in database within GET requests. 

LOCALLY TESTED

[DSND-2875](https://companieshouse.atlassian.net/browse/DSND-2875)

[DSND-2875]: https://companieshouse.atlassian.net/browse/DSND-2875?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ