### PR TITLE
DSND-2875: Remove the routes.yaml from makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,6 @@ endif
 	mvn package -DskipTests=true
 	$(eval tmpdir:=$(shell mktemp -d build-XXXXXXXXXX))
 	cp ./start.sh $(tmpdir)
-	cp ./routes.yaml $(tmpdir)
 	cp ./target/$(artifact_name)-$(version).jar $(tmpdir)/$(artifact_name).jar
 	cd $(tmpdir); zip -r ../$(artifact_name)-$(version).zip *
 	rm -rf $(tmpdir)


### PR DESCRIPTION
 
* currently the build-release job fails on concourse with `cp ./routes.yaml build-QhSThEwMUi`
`cp: cannot stat './routes.yaml': No such file or directory`
* this removes the routes.yaml reference from the makefile so that the concourse build-release job will work. 
* was not detected earlier as seems only this job uses build package.

[DSND-2875](https://companieshouse.atlassian.net/browse/DSND-2875)



[DSND-2875]: https://companieshouse.atlassian.net/browse/DSND-2875?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ