### PR TITLE
DSND-3193: Return 409 given stale delta on PUT

### DIFF
--- a/src/itest/java/uk/gov/companieshouse/disqualifiedofficersdataapi/steps/CorporateDisqualificationSteps.java
+++ b/src/itest/java/uk/gov/companieshouse/disqualifiedofficersdataapi/steps/CorporateDisqualificationSteps.java
@@ -93,7 +93,7 @@ public class CorporateDisqualificationSteps {
         corporateDisqualification.setDeltaAt(deltaAt);
 
         mongoTemplate.save(corporateDisqualification);
-        CucumberContext.CONTEXT.set("disqualificationData",corpData);
+        CucumberContext.CONTEXT.set("disqualificationData",corporateDisqualification);
     }
 
     @When("I send corporate GET request with officer Id {string}")
@@ -152,9 +152,13 @@ public class CorporateDisqualificationSteps {
 
     @And("the corporate record with id {string} is unchanged")
     public void the_corporate_record_with_id_is_unchanged(String officerId) {
-        CorporateDisqualificationApi actual = corporateRepository.findById(officerId).get().getData();
-        CorporateDisqualificationApi expected = CucumberContext.CONTEXT.get("disqualificationData");
-        Assertions.assertEquals(expected, actual);
+        CorporateDisqualificationDocument actual = corporateRepository.findById(officerId).get();
+        CorporateDisqualificationDocument expected = CucumberContext.CONTEXT.get("disqualificationData");
+
+        Assertions.assertEquals(expected.getData(), actual.getData());
+        Assertions.assertEquals(expected.getDeltaAt(), actual.getDeltaAt());
+        Assertions.assertEquals(expected.getId(), actual.getId());
+        Assertions.assertEquals(expected.isCorporateOfficer(), actual.isCorporateOfficer());
     }
 
     @After

--- a/src/itest/java/uk/gov/companieshouse/disqualifiedofficersdataapi/steps/CorporateDisqualificationSteps.java
+++ b/src/itest/java/uk/gov/companieshouse/disqualifiedofficersdataapi/steps/CorporateDisqualificationSteps.java
@@ -7,6 +7,7 @@ import io.cucumber.java.en.And;
 import io.cucumber.java.en.Given;
 import io.cucumber.java.en.Then;
 import io.cucumber.java.en.When;
+import org.junit.jupiter.api.Assertions;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.web.client.TestRestTemplate;
 import org.springframework.core.io.ClassPathResource;
@@ -92,6 +93,7 @@ public class CorporateDisqualificationSteps {
         corporateDisqualification.setDeltaAt(deltaAt);
 
         mongoTemplate.save(corporateDisqualification);
+        CucumberContext.CONTEXT.set("disqualificationData",corpData);
     }
 
     @When("I send corporate GET request with officer Id {string}")
@@ -146,6 +148,13 @@ public class CorporateDisqualificationSteps {
         assertThat(expected.getName()).isEqualTo(actual.getName());
         assertThat(expected.getDisqualifications()).isEqualTo(actual.getDisqualifications());
         assertThat(expected.getKind()).isEqualTo(actual.getKind());
+    }
+
+    @And("the corporate record with id {string} is unchanged")
+    public void the_corporate_record_with_id_is_unchanged(String officerId) {
+        CorporateDisqualificationApi actual = corporateRepository.findById(officerId).get().getData();
+        CorporateDisqualificationApi expected = CucumberContext.CONTEXT.get("disqualificationData");
+        Assertions.assertEquals(expected, actual);
     }
 
     @After

--- a/src/itest/java/uk/gov/companieshouse/disqualifiedofficersdataapi/steps/CorporateDisqualificationSteps.java
+++ b/src/itest/java/uk/gov/companieshouse/disqualifiedofficersdataapi/steps/CorporateDisqualificationSteps.java
@@ -3,6 +3,7 @@ package uk.gov.companieshouse.disqualifiedofficersdataapi.steps;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.cucumber.java.After;
 import io.cucumber.java.Before;
+import io.cucumber.java.en.And;
 import io.cucumber.java.en.Given;
 import io.cucumber.java.en.Then;
 import io.cucumber.java.en.When;
@@ -80,6 +81,19 @@ public class CorporateDisqualificationSteps {
         mongoTemplate.save(corporateDisqualification);
     }
 
+    @And("the corporate disqualified officer information exists for {string} with delta_at {string}")
+    public void the_disqualification_information_exists_for_with_delta_at(String officerId, String deltaAt) throws IOException {
+        File corpFile = new ClassPathResource("/json/output/retrieve_corporate_disqualified_officer.json").getFile();
+        CorporateDisqualificationApi corpData = objectMapper.readValue(corpFile, CorporateDisqualificationApi.class);
+        CorporateDisqualificationDocument corporateDisqualification = new CorporateDisqualificationDocument();
+        corporateDisqualification.setData(corpData);
+        corporateDisqualification.setId(officerId);
+        corporateDisqualification.setCorporateOfficer(true);
+        corporateDisqualification.setDeltaAt(deltaAt);
+
+        mongoTemplate.save(corporateDisqualification);
+    }
+
     @When("I send corporate GET request with officer Id {string}")
     public void i_send_corporate_get_request_with_officer_id(String officerId) {
         String uri = "/disqualified-officers/corporate/{officerId}";
@@ -112,7 +126,7 @@ public class CorporateDisqualificationSteps {
         headers.set("ERIC-Identity-Type", "KEY");
         headers.set("ERIC-Authorised-Key-Privileges", "internal-app");
 
-        HttpEntity request = new HttpEntity(data, headers);
+        HttpEntity<String> request = new HttpEntity<>(data, headers);
         String uri = "/disqualified-officers/corporate/{officerId}/internal";
         CucumberContext.CONTEXT.set("officerType", DisqualificationResourceType.CORPORATE);
         String officerId = "1234567891";

--- a/src/itest/java/uk/gov/companieshouse/disqualifiedofficersdataapi/steps/NaturalDisqualificationSteps.java
+++ b/src/itest/java/uk/gov/companieshouse/disqualifiedofficersdataapi/steps/NaturalDisqualificationSteps.java
@@ -7,6 +7,7 @@ import io.cucumber.java.en.And;
 import io.cucumber.java.en.Given;
 import io.cucumber.java.en.Then;
 import io.cucumber.java.en.When;
+import org.junit.jupiter.api.Assertions;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.web.client.TestRestTemplate;
 import org.springframework.core.io.ClassPathResource;
@@ -93,7 +94,6 @@ public class NaturalDisqualificationSteps {
         naturalDisqualification.setDeltaAt(deltaAt);
 
         mongoTemplate.save(naturalDisqualification);
-        natData.setKind(KindEnum.NATURAL_DISQUALIFICATION);
         CucumberContext.CONTEXT.set("disqualificationData", natData);
     }
 
@@ -171,6 +171,13 @@ public class NaturalDisqualificationSteps {
         assertThat(expected.getDisqualifications()).isEqualTo(actual.getDisqualifications());
         assertThat(expected.getDateOfBirth()).isEqualTo(actual.getDateOfBirth());
         assertThat(expected.getKind()).isEqualTo(actual.getKind());
+    }
+
+    @And("the natural record with id {string} is unchanged")
+    public void the_natural_record_with_id_is_unchanged(String officerId) {
+        NaturalDisqualificationApi actual = naturalRepository.findById(officerId).get().getData();
+        NaturalDisqualificationApi expected = CucumberContext.CONTEXT.get("disqualificationData");
+        Assertions.assertEquals(expected, actual);
     }
 
     @After

--- a/src/itest/java/uk/gov/companieshouse/disqualifiedofficersdataapi/steps/NaturalDisqualificationSteps.java
+++ b/src/itest/java/uk/gov/companieshouse/disqualifiedofficersdataapi/steps/NaturalDisqualificationSteps.java
@@ -3,6 +3,7 @@ package uk.gov.companieshouse.disqualifiedofficersdataapi.steps;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.cucumber.java.After;
 import io.cucumber.java.Before;
+import io.cucumber.java.en.And;
 import io.cucumber.java.en.Given;
 import io.cucumber.java.en.Then;
 import io.cucumber.java.en.When;
@@ -76,6 +77,20 @@ public class NaturalDisqualificationSteps {
         naturalDisqualification.setData(natData);
         naturalDisqualification.setId(officerId);
         naturalDisqualification.setDeltaAt("20230925171003950844");
+
+        mongoTemplate.save(naturalDisqualification);
+        natData.setKind(KindEnum.NATURAL_DISQUALIFICATION);
+        CucumberContext.CONTEXT.set("disqualificationData", natData);
+    }
+
+    @And("the natural disqualified officer information exists for {string} with delta_at {string}")
+    public void the_natural_disqualification_information_exists_for_with_delta_at(String officerId, String deltaAt) throws IOException {
+        File natFile = new ClassPathResource("/json/output/retrieve_natural_disqualified_officer.json").getFile();
+        NaturalDisqualificationApi natData = objectMapper.readValue(natFile, NaturalDisqualificationApi.class);
+        NaturalDisqualificationDocument naturalDisqualification = new NaturalDisqualificationDocument();
+        naturalDisqualification.setData(natData);
+        naturalDisqualification.setId(officerId);
+        naturalDisqualification.setDeltaAt(deltaAt);
 
         mongoTemplate.save(naturalDisqualification);
         natData.setKind(KindEnum.NATURAL_DISQUALIFICATION);

--- a/src/itest/java/uk/gov/companieshouse/disqualifiedofficersdataapi/steps/NaturalDisqualificationSteps.java
+++ b/src/itest/java/uk/gov/companieshouse/disqualifiedofficersdataapi/steps/NaturalDisqualificationSteps.java
@@ -94,7 +94,7 @@ public class NaturalDisqualificationSteps {
         naturalDisqualification.setDeltaAt(deltaAt);
 
         mongoTemplate.save(naturalDisqualification);
-        CucumberContext.CONTEXT.set("disqualificationData", natData);
+        CucumberContext.CONTEXT.set("disqualificationData", naturalDisqualification);
     }
 
     @When("I send natural GET request with officer Id {string}")
@@ -175,9 +175,12 @@ public class NaturalDisqualificationSteps {
 
     @And("the natural record with id {string} is unchanged")
     public void the_natural_record_with_id_is_unchanged(String officerId) {
-        NaturalDisqualificationApi actual = naturalRepository.findById(officerId).get().getData();
-        NaturalDisqualificationApi expected = CucumberContext.CONTEXT.get("disqualificationData");
-        Assertions.assertEquals(expected, actual);
+        NaturalDisqualificationDocument actual = naturalRepository.findById(officerId).get();
+        NaturalDisqualificationDocument expected = CucumberContext.CONTEXT.get("disqualificationData");
+
+        Assertions.assertEquals(expected.getData(), actual.getData());
+        Assertions.assertEquals(expected.getDeltaAt(), actual.getDeltaAt());
+        Assertions.assertEquals(expected.getId(), actual.getId());
     }
 
     @After

--- a/src/itest/resources/features/corporate_disqualification.feature
+++ b/src/itest/resources/features/corporate_disqualification.feature
@@ -22,3 +22,14 @@ Feature: Process corporate disqualified officer information
     Examples:
       | officerId     | result                                    |
       | 1234567891    | retrieve_corporate_disqualified_officer   |
+
+  Scenario Outline: Processing corporate disqualified officer with stale delta_at returns 409
+
+    Given disqualified officers data api service is running
+    And the corporate disqualified officer information exists for "<officer_id>" with delta_at "<delta_at>"
+    When I send corporate PUT request with payload "<data>" file
+    Then I should receive 409 status code
+
+    Examples:
+      | officer_id | delta_at             | data                           |
+      | 1234567891 | 20500405155100786000 | corporate_disqualified_officer |

--- a/src/itest/resources/features/corporate_disqualification.feature
+++ b/src/itest/resources/features/corporate_disqualification.feature
@@ -29,6 +29,8 @@ Feature: Process corporate disqualified officer information
     And the corporate disqualified officer information exists for "<officer_id>" with delta_at "<delta_at>"
     When I send corporate PUT request with payload "<data>" file
     Then I should receive 409 status code
+    And the corporate record with id "<officer_id>" is unchanged
+    And the CHS Kafka API is not invoked
 
     Examples:
       | officer_id | delta_at             | data                           |

--- a/src/itest/resources/features/natural_disqualification.feature
+++ b/src/itest/resources/features/natural_disqualification.feature
@@ -22,3 +22,14 @@ Feature: Process natural disqualified officer information
     Examples:
       | officerId     | result                                    |
       | 1234567890    | retrieve_natural_disqualified_officer     |
+
+  Scenario Outline: Processing natural disqualified officer with stale delta_at returns 409
+
+    Given disqualified officers data api service is running
+    And the natural disqualified officer information exists for "<officer_id>" with delta_at "<delta_at>"
+    When I send natural PUT request with payload "<data>" file
+    Then I should receive 409 status code
+
+    Examples:
+      | officer_id | delta_at             | data                         |
+      | 1234567890 | 20500405155100786000 | natural_disqualified_officer |

--- a/src/itest/resources/features/natural_disqualification.feature
+++ b/src/itest/resources/features/natural_disqualification.feature
@@ -29,6 +29,8 @@ Feature: Process natural disqualified officer information
     And the natural disqualified officer information exists for "<officer_id>" with delta_at "<delta_at>"
     When I send natural PUT request with payload "<data>" file
     Then I should receive 409 status code
+    And the natural record with id "<officer_id>" is unchanged
+    And the CHS Kafka API is not invoked
 
     Examples:
       | officer_id | delta_at             | data                         |

--- a/src/main/java/uk/gov/companieshouse/disqualifiedofficersdataapi/service/DisqualifiedOfficerService.java
+++ b/src/main/java/uk/gov/companieshouse/disqualifiedofficersdataapi/service/DisqualifiedOfficerService.java
@@ -69,7 +69,7 @@ public class DisqualifiedOfficerService {
             saveAndCallChsKafka(contextId, officerId, document, DisqualificationResourceType.NATURAL,
                     existingDocument.orElse(null));
         } else {
-            LOGGER.info(STALE_DELTA_AT_MESSAGE, DataMapHolder.getLogMap());
+            LOGGER.error(STALE_DELTA_AT_MESSAGE, DataMapHolder.getLogMap());
             throw new ConflictException(STALE_DELTA_AT_MESSAGE);
         }
     }
@@ -93,7 +93,7 @@ public class DisqualifiedOfficerService {
             saveAndCallChsKafka(contextId, officerId, document, DisqualificationResourceType.CORPORATE,
                     existingDocument.orElse(null));
         } else {
-            LOGGER.info(STALE_DELTA_AT_MESSAGE, DataMapHolder.getLogMap());
+            LOGGER.error(STALE_DELTA_AT_MESSAGE, DataMapHolder.getLogMap());
             throw new ConflictException(STALE_DELTA_AT_MESSAGE);
         }
     }

--- a/src/main/java/uk/gov/companieshouse/disqualifiedofficersdataapi/service/DisqualifiedOfficerService.java
+++ b/src/main/java/uk/gov/companieshouse/disqualifiedofficersdataapi/service/DisqualifiedOfficerService.java
@@ -10,6 +10,7 @@ import uk.gov.companieshouse.api.disqualification.InternalNaturalDisqualificatio
 import uk.gov.companieshouse.disqualifiedofficersdataapi.api.DisqualifiedOfficerApiService;
 import uk.gov.companieshouse.disqualifiedofficersdataapi.api.ResourceChangedRequest;
 import uk.gov.companieshouse.disqualifiedofficersdataapi.exceptions.BadGatewayException;
+import uk.gov.companieshouse.disqualifiedofficersdataapi.exceptions.ConflictException;
 import uk.gov.companieshouse.disqualifiedofficersdataapi.exceptions.NotFoundException;
 import uk.gov.companieshouse.disqualifiedofficersdataapi.logging.DataMapHolder;
 import uk.gov.companieshouse.disqualifiedofficersdataapi.model.CorporateDisqualificationDocument;
@@ -69,6 +70,7 @@ public class DisqualifiedOfficerService {
                     existingDocument.orElse(null));
         } else {
             LOGGER.info(STALE_DELTA_AT_MESSAGE, DataMapHolder.getLogMap());
+            throw new ConflictException(STALE_DELTA_AT_MESSAGE);
         }
     }
 
@@ -92,6 +94,7 @@ public class DisqualifiedOfficerService {
                     existingDocument.orElse(null));
         } else {
             LOGGER.info(STALE_DELTA_AT_MESSAGE, DataMapHolder.getLogMap());
+            throw new ConflictException(STALE_DELTA_AT_MESSAGE);
         }
     }
 

--- a/src/test/java/uk/gov/companieshouse/disqualifiedofficersdataapi/service/DisqualifiedOfficerServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/disqualifiedofficersdataapi/service/DisqualifiedOfficerServiceTest.java
@@ -25,6 +25,7 @@ import uk.gov.companieshouse.api.disqualification.NaturalDisqualificationApi;
 import uk.gov.companieshouse.disqualifiedofficersdataapi.api.DisqualifiedOfficerApiService;
 import uk.gov.companieshouse.disqualifiedofficersdataapi.api.ResourceChangedRequest;
 import uk.gov.companieshouse.disqualifiedofficersdataapi.exceptions.BadGatewayException;
+import uk.gov.companieshouse.disqualifiedofficersdataapi.exceptions.ConflictException;
 import uk.gov.companieshouse.disqualifiedofficersdataapi.model.CorporateDisqualificationDocument;
 import uk.gov.companieshouse.disqualifiedofficersdataapi.model.Created;
 import uk.gov.companieshouse.disqualifiedofficersdataapi.model.DisqualificationDocument;
@@ -174,8 +175,9 @@ class DisqualifiedOfficerServiceTest {
         when(repository.findById(OFFICER_ID)).thenReturn(Optional.of(document));
         when(deltaAtHandler.isRequestStale(any(OffsetDateTime.class), any())).thenReturn(true);
 
-        service.processNaturalDisqualification("", OFFICER_ID, request);
+        Executable actual = () -> service.processNaturalDisqualification("", OFFICER_ID, request);
 
+        assertThrows(ConflictException.class, actual);
         verifyNoMoreInteractions(repository);
         verifyNoInteractions(transformer);
         verifyNoInteractions(disqualifiedOfficerApiService);
@@ -254,8 +256,9 @@ class DisqualifiedOfficerServiceTest {
         when(repository.findById(OFFICER_ID)).thenReturn(Optional.of(document));
         when(deltaAtHandler.isRequestStale(any(OffsetDateTime.class), any())).thenReturn(true);
 
-        service.processCorporateDisqualification("", OFFICER_ID, corpRequest);
+        Executable actual = () -> service.processCorporateDisqualification("", OFFICER_ID, corpRequest);
 
+        assertThrows(ConflictException.class, actual);
         verifyNoMoreInteractions(repository);
         verifyNoInteractions(transformer);
         verifyNoInteractions(disqualifiedOfficerApiService);


### PR DESCRIPTION
* Throw conflict exception when delta_at is stale in put processing
* Fix failing tests

Resolves [DSND-3193](https://companieshouse.atlassian.net/browse/DSND-3193)

[DSND-3193]: https://companieshouse.atlassian.net/browse/DSND-3193?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ